### PR TITLE
add continuous integration via Travis CI with .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+os: linux
+dist: trusty
+language: c
+sudo: required
+#
+matrix:
+  include:
+    - name: "gcc 4.8"
+      env: MATRIX_EVAL="CC=gcc && CXX=g++"
+
+    - name: "gcc 5"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-5
+      env: MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - name: "gcc 6"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-6
+      env: MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    - name: "gcc 7"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-7
+      env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - name: "clang"
+      env: MATRIX_EVAL="CC=clang && CXX=clang++"
+
+#
+before_install:
+  - sudo apt-get install -y regina-rexx libregina3-dev
+  - eval "${MATRIX_EVAL}"
+
+#
+before_script:
+  - util/bldlvlck
+  - ./autogen.sh
+  - ./configure 
+  - bash -c 'echo CC=$CC; echo CXX=$CXX'
+  - bash -c '${CC} --version'
+
+#
+script:
+  - make
+  - make check


### PR DESCRIPTION
I've setup [Travis CI](https://travis-ci.org/) integration for hyperion. The pull provides the `.travis.yml` file, which describes
- the build matrix, covering gcc 4.8, 5.x, 6.x, 7.x and clang 5.x
- the required packages (`regina-rexx` as provided by Ubuntu)
- the build script, simply `make` and `make check`

To make it work, you have first to sign up with Travis, best via the GitHub account, and than to activate tracking of the hyperion repository. If it is working, it is customary to add the `build badge` to the `README`. Hope you enjoy continuous integration.

Travis CI log of the last build for my fork of hyperion before writing the pull request can be inspected under https://travis-ci.org/wfjm/hyperion/builds/420555079 .
  
