### PR TITLE
add continuous integration via Travis CI with .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,31 +5,36 @@ sudo: required
 #
 matrix:
   include:
-    - name: "gcc 4.8"
+    - name: "Ub 14.04 -- gcc 4.8.4"
+      dist: trusty
       env: MATRIX_EVAL="CC=gcc"
 
-    - name: "gcc 5"
-      addons:
-        apt:
-          sources:  ubuntu-toolchain-r-test
-          packages: g++-5
-      env: MATRIX_EVAL="CC=gcc-5"
-
-    - name: "gcc 6"
+    - name: "Ub 14.04 -- gcc 6.5.0"
+      dist: trusty
       addons:
         apt:
           sources:  ubuntu-toolchain-r-test
           packages: g++-6
       env: MATRIX_EVAL="CC=gcc-6"
 
-    - name: "gcc 7"
+    - name: "Ub 14.04 -- gcc 7.4.0"
+      dist: trusty
       addons:
         apt:
           sources:  ubuntu-toolchain-r-test
           packages: g++-7
       env: MATRIX_EVAL="CC=gcc-7"
 
-    - name: "clang"
+    - name: "Ub 14.04 -- clang 5.0.0"
+      dist: trusty
+      env: MATRIX_EVAL="CC=clang"
+
+    - name: "Ub 16.04 -- gcc 5.4.0"
+      dist: xenial
+      env: MATRIX_EVAL="CC=gcc"
+
+    - name: "Ub 16.04 -- clang 7.0.0"
+      dist: xenial
       env: MATRIX_EVAL="CC=clang"
 
 #
@@ -46,5 +51,5 @@ before_script:
 
 #
 script:
-  - make
+  - make -j 2
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+os: linux
+dist: trusty
+language: c
+sudo: required
+#
+matrix:
+  include:
+    - name: "gcc 4.8"
+      env: MATRIX_EVAL="CC=gcc"
+
+    - name: "gcc 5"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-5
+      env: MATRIX_EVAL="CC=gcc-5"
+
+    - name: "gcc 6"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-6
+      env: MATRIX_EVAL="CC=gcc-6"
+
+    - name: "gcc 7"
+      addons:
+        apt:
+          sources:  ubuntu-toolchain-r-test
+          packages: g++-7
+      env: MATRIX_EVAL="CC=gcc-7"
+
+    - name: "clang"
+      env: MATRIX_EVAL="CC=clang"
+
+#
+before_install:
+  - sudo apt-get install -y regina-rexx libregina3-dev
+  - eval "${MATRIX_EVAL}"
+
+#
+before_script:
+  - util/bldlvlck
+  - ./autogen.sh
+  - ./configure --enable-regina-rexx
+  - bash -c '${CC} --version'
+
+#
+script:
+  - make
+  - make check


### PR DESCRIPTION
This is a retry of #137 which had to be scuttled due to #142.
The generic statements about [Travis CI](https://travis-ci.org) written in #137 stay of course valid.
The Regina issue was resolved with d73fe15, and the build succeed now, see [build 13](https://travis-ci.org/wfjm/hyperion/builds/423355312).

Before you decide to merge in this pull request your repository should be registered with  [Travis CI](https://travis-ci.org). Simply sign-in with your GitHub account. That sets up all the integration on the GitHub end (most notably the [webhook](https://developer.github.com/webhooks/) which triggers Travis builds). On the Travis side you have to enable the `hyperion` repository. That's all, the defaults work fine for this straightforward case.

At this point I stick with Regina-REXX. If you find Travis integration useful, I'll try to extend the build matrix such that also OOREXX is included.
