### PR TITLE
Make console more faithful

### DIFF
--- a/console.c
+++ b/console.c
@@ -2496,25 +2496,6 @@ static void constty_input( TELNET* tn, const BYTE* buffer, U32 size )
             return;
         }
 
-        /* Check for Ctrl-C */
-        if (buffer[i] == 0x03)
-        {
-            tn->got_break = TRUE;
-            dev->keybdrem = 0;
-            return;
-        }
-
-        /* Check for ASCII backspace/delete */
-        if (0
-            || buffer[i] == 0x08    // BS
-            || buffer[i] == 0x7F    // DEL
-        )
-        {
-            if (dev->keybdrem > 0)
-                dev->keybdrem--;
-            continue;
-        }
-
         /* Copy character to keyboard buffer */
         dev->buf[ dev->keybdrem++ ] = buffer[i];
 
@@ -4281,11 +4262,8 @@ BYTE    stat;                           /* Unit status               */
         for (len = 0; len < num; len++)
         {
             c = guest_to_host( iobuf[len] );
-            /* Replace any non-printable characters with a blank
-               except keep carriage returns and newlines as-is. */
-            if (!isprint(c) && c != '\r' && c!= '\n')
-                c = ' ';
-            iobuf[len] = c;   /* only printable or CR/LF allowed */
+            /* Leave it up to guest OS to filter characters. */
+            iobuf[len] = c;
         } /* end for(len) */
 
         ASSERT(len == num);


### PR DESCRIPTION
This is a smallish change, so I just started the pull request without more ado.

I'm connecting a simulated terminal to a 70's-era hypertext system (FRESS) that runs under VM. In those days Brown University's VM installation (and I suspect most installations that had ASCII terminals) used custom translation tables, so that they could:

  + round trip ASCII<->EBCDIC
  + support ASCII terminal character sequences that included "weird" characters.

This change does two things:

1. It removes the filtering of "unprintable" characters from the network pipe.
&nbsp;
Standard telnet recognizes `\r\n` as the line end, but the raw characters can also be transmitted by the client without invoking that processing if the explicit escapes are used. (To solve my problem with the old VM code I would have to modify CP's translate tables, but that's an issue at my end and should not be a concern of Hercules).

2. It also removes the direct interpretation of Ctrl-C and Backspace.
&nbsp;
Telnet has line-editing support built into the protocol, and Hercules speaks line mode anyway, which means the client is free to implement local editing. From other comments I've seen on the lists and in the code, it seems that some windows telnet clients may not be able to do this, in which case it may make sense to introduce a device option. Since this change basically improves compatibility with _standard_ telnet however, I've not made such an option.

Obviously this is a mod I could support myself indefinitely, but I'd prefer not to, especially because I'm trying to get the old code and data ready to be an executable demo in an archive. Not having to have a custom patch would aid that process.

I'm using the console devices because I've never been able to get the comm lines working on VM, and because the console devices can share a single port, whereas `commadpt` does not support that. Certainly allowing more bytes to be transmitted to and from consoles does not violate the architecture, even if contemporary hardware would not have transmitted or received all those codes without errors or undefined behavior.