### PR TITLE
Updates for Visual Studio 2019

### DIFF
--- a/Hercules_VS2019.sln
+++ b/Hercules_VS2019.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Hercules", "Hercules_VS2019.vcxproj", "{A0F495FF-9C35-4DFB-A51A-0427D8420779}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		All-All|Win32 = All-All|Win32
+		All-All|x64 = All-All|x64
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Debug-All|Win32 = Debug-All|Win32
+		Debug-All|x64 = Debug-All|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+		Release-All|Win32 = Release-All|Win32
+		Release-All|x64 = Release-All|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.All-All|Win32.ActiveCfg = All-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.All-All|Win32.Build.0 = All-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.All-All|x64.ActiveCfg = All-All|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.All-All|x64.Build.0 = All-All|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug|Win32.Build.0 = Debug|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug|x64.ActiveCfg = Debug|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug|x64.Build.0 = Debug|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug-All|Win32.ActiveCfg = Debug-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug-All|Win32.Build.0 = Debug-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug-All|x64.ActiveCfg = Debug-All|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Debug-All|x64.Build.0 = Debug-All|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release|Win32.ActiveCfg = Release|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release|Win32.Build.0 = Release|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release|x64.ActiveCfg = Release|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release|x64.Build.0 = Release|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release-All|Win32.ActiveCfg = Release-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release-All|Win32.Build.0 = Release-All|Win32
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release-All|x64.ActiveCfg = Release-All|x64
+		{A0F495FF-9C35-4DFB-A51A-0427D8420779}.Release-All|x64.Build.0 = Release-All|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CE1B8331-D6BB-4399-B1CC-3EDF78317485}
+	EndGlobalSection
+EndGlobal

--- a/Hercules_VS2019.vcxproj
+++ b/Hercules_VS2019.vcxproj
@@ -1,0 +1,1396 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="16.1" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="All-All|Win32">
+      <Configuration>All-All</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="All-All|x64">
+      <Configuration>All-All</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-All|Win32">
+      <Configuration>Debug-All</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-All|x64">
+      <Configuration>Debug-All</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-All|Win32">
+      <Configuration>Release-All</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release-All|x64">
+      <Configuration>Release-All</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>Hercules</ProjectName>
+    <ProjectGuid>{A0F495FF-9C35-4DFB-A51A-0427D8420779}</ProjectGuid>
+    <RootNamespace>Hercules</RootNamespace>
+    <Keyword>MakeFileProj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='All-All|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='All-All|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='All-All|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='All-All|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>14.0.25431.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>./msvc.debug.dllmod.bin\</OutDir>
+    <IntDir>./msvc.debug.dllmod.obj\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat DEBUG makefile.msvc 32 -title "** The SoftDevLabs version of Hercules **"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat DEBUG makefile.msvc 32 -a -title "** The SoftDevLabs version of Hercules **"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat DEBUG makefile.msvc 32 clean -title "** The SoftDevLabs version of Hercules **"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;_FEATURE_INTEGRATED_3270_CONSOLE;FEATURE_SERVICE_PROCESSOR;FEATURE_EXTENDED_STORAGE_KEYS;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_DEBUG;DEBUG;_MSVC_;CPU=i386;HOST_ARCH=i386;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_QUEUED_DIRECT_IO;_FEATURE_SIE;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>./msvc.debug.AMD64.bin\</OutDir>
+    <IntDir>./msvc.debug.AMD64.bin\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat DEBUG-X64 makefile.msvc 64 -title "** The SoftDevLabs version of Hercules **"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat DEBUG-X64 makefile.msvc 64 -a -title "** The SoftDevLabs version of Hercules **"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat DEBUG-X64 makefile.msvc 64 clean -title "** The SoftDevLabs version of Hercules **"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;_FEATURE_INTEGRATED_3270_CONSOLE;FEATURE_SERVICE_PROCESSOR;FEATURE_EXTENDED_STORAGE_KEYS;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_WIN64;_DEBUG;DEBUG;_MSVC_;CPU=AMD64;HOST_ARCH=AMD64;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_QUEUED_DIRECT_IO;_FEATURE_SIE;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>./msvc.dllmod.bin\</OutDir>
+    <IntDir>./msvc.dllmod.obj\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat RETAIL makefile.msvc 32 -title "** The SoftDevLabs version of Hercules **"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat RETAIL makefile.msvc 32 -a -title "** The SoftDevLabs version of Hercules **"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat RETAIL makefile.msvc 32 clean -title "** The SoftDevLabs version of Hercules **"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;_FEATURE_INTEGRATED_3270_CONSOLE;FEATURE_SERVICE_PROCESSOR;FEATURE_EXTENDED_STORAGE_KEYS;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;NDEBUG;_MSVC_;CPU=i386;HOST_ARCH=i386;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_QUEUED_DIRECT_IO;_FEATURE_SIE;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>./msvc.AMD64.bin\</OutDir>
+    <IntDir>./msvc.AMD64.bin\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat RETAIL-X64 makefile.msvc 64 -title "** The SoftDevLabs version of Hercules **"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat RETAIL-X64 makefile.msvc 64 -a -title "** The SoftDevLabs version of Hercules **"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat RETAIL-X64 makefile.msvc 64 clean -title "** The SoftDevLabs version of Hercules **"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;_FEATURE_INTEGRATED_3270_CONSOLE;FEATURE_SERVICE_PROCESSOR;FEATURE_EXTENDED_STORAGE_KEYS;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_WIN64;NDEBUG;_MSVC_;CPU=AMD64;HOST_ARCH=AMD64;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_QUEUED_DIRECT_IO;_FEATURE_SIE;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat DEBUG-ALL makefile.msvc 32 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat DEBUG-ALL makefile.msvc 32 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat DEBUG-ALL makefile.msvc 32 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_DEBUG;DEBUG;_MSVC_;CPU=i386;HOST_ARCH=i386;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat DEBUG-ALL makefile.msvc 64 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat DEBUG-ALL makefile.msvc 64 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat DEBUG-ALL makefile.msvc 64 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_WIN64;_DEBUG;DEBUG;_MSVC_;CPU=AMD64;HOST_ARCH=AMD64;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat RETAIL-ALL makefile.msvc 32 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat RETAIL-ALL makefile.msvc 32 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat RETAIL-ALL makefile.msvc 32 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;NDEBUG;_MSVC_;CPU=i386;HOST_ARCH=i386;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat RETAIL-ALL makefile.msvc 64 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat RETAIL-ALL makefile.msvc 64 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat RETAIL-ALL makefile.msvc 64 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_WIN64;NDEBUG;_MSVC_;CPU=AMD64;HOST_ARCH=AMD64;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='All-All|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat ALL-ALL makefile.msvc 32 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat ALL-ALL makefile.msvc 32 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat ALL-ALL makefile.msvc 32 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_MSVC_;CPU=i386;HOST_ARCH=i386;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='All-All|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\</IntDir>
+    <NMakeBuildCommandLine>makefile.bat ALL-ALL makefile.msvc 64 "$(SolutionDir)" "$(ProjectFileName)"</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>makefile.bat ALL-ALL makefile.msvc 64 -a "$(SolutionDir)" "$(ProjectFileName)"</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>makefile.bat ALL-ALL makefile.msvc 64 clean "$(SolutionDir)" "$(ProjectFileName)"</NMakeCleanCommandLine>
+    <NMakeOutput>$(OutDir)</NMakeOutput>
+    <NMakePreprocessorDefinitions>OPTION_SHARED_DEVICES;FEATURE_STORE_SYSTEM_INFORMATION;OPTION_HTTP_SERVER;_DAT_C;FEATURE_PROGRAM_DIRECTED_REIPL;FEATURE_EMULATE_VM;ENABLE_IPV6;OPTION_CMPSC_2012;FEATURE_BINARY_FLOATING_POINT;WIN32;_WIN64;_MSVC_;CPU=AMD64;HOST_ARCH=AMD64;OPTION_FTHREADS;EXTERNALGUI;FEATURE_CHANNEL_SUBSYSTEM;FEATURE_CANCEL_IO_FACILITY;FEATURE_001_ZARCH_INSTALLED_FACILITY;FEATURE_011_CONFIG_TOPOLOGY_FACILITY;OPTION_HAO;HAVE_REGINA_REXXSAA_H;OPTION_CMDTGT;_FEATURE_SYSTEM_CONSOLE;FEATURE_CHSC;OPTION_PTTRACE;FEATURE_CMPSC;HAVE_REGINA_REXX;HAVE_OBJECT_REXX;FEATURE_S370_CHANNEL;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
+    <NMakeIncludeSearchPath>crypto\include;decNumber\include;SoftFloat\include;telnet\include;$(ProjectDir);$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|Win32'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-All|x64'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|Win32'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-All|x64'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='All-All|Win32'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='All-All|x64'">
+    <BuildLog>
+      <Path>$(OutDir)BuildLog-$(Platform)-$(Configuration).txt</Path>
+    </BuildLog>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="_archdep_templ.c" />
+    <ClCompile Include="archlvl.c" />
+    <ClCompile Include="assist.c" />
+    <ClCompile Include="awstape.c" />
+    <ClCompile Include="bldcfg.c" />
+    <ClCompile Include="bootstrap.c" />
+    <ClCompile Include="build_pch.c" />
+    <ClCompile Include="cache.c" />
+    <ClCompile Include="cardpch.c" />
+    <ClCompile Include="cardrdr.c" />
+    <ClCompile Include="cckdcdsk.c" />
+    <ClCompile Include="cckdcomp.c" />
+    <ClCompile Include="cckddasd.c" />
+    <ClCompile Include="cckddiag.c" />
+    <ClCompile Include="cckdswap.c" />
+    <ClCompile Include="cckdutil.c" />
+    <ClCompile Include="cckdcdsk64.c" />
+    <ClCompile Include="cckdcomp64.c" />
+    <ClCompile Include="cckddasd64.c" />
+    <ClCompile Include="cckddiag64.c" />
+    <ClCompile Include="cckdswap64.c" />
+    <ClCompile Include="cckdmap.c" />
+    <ClCompile Include="convto64.c" />
+    <ClCompile Include="cckdutil64.c" />
+    <ClCompile Include="cgibin.c" />
+    <ClCompile Include="channel.c" />
+    <ClCompile Include="chsc.c" />
+    <ClCompile Include="ckddasd.c" />
+    <ClCompile Include="ckddasd64.c" />
+    <ClCompile Include="clock.c" />
+    <ClCompile Include="cmdtab.c" />
+    <ClCompile Include="cmpscdbg.c" />
+    <ClCompile Include="cmpscdct.c" />
+    <ClCompile Include="cmpscget.c" />
+    <ClCompile Include="cmpscmem.c" />
+    <ClCompile Include="cmpscput.c" />
+    <ClCompile Include="cmpsc_2012.c" />
+    <ClCompile Include="codepage.c" />
+    <ClCompile Include="comm3705.c" />
+    <ClCompile Include="commadpt.c" />
+    <ClCompile Include="con1052c.c" />
+    <ClCompile Include="config.c" />
+    <ClCompile Include="console.c" />
+    <ClCompile Include="conspawn.c" />
+    <ClCompile Include="control.c" />
+    <ClCompile Include="cpu.c" />
+    <ClCompile Include="crypto.c" />
+    <ClCompile Include="dyncrypt.c" />
+    <ClCompile Include="ctcadpt.c" />
+    <ClCompile Include="ctc_ctci.c" />
+    <ClCompile Include="ctc_lcs.c" />
+    <ClCompile Include="ctc_ptp.c" />
+    <ClCompile Include="dasdcat.c" />
+    <ClCompile Include="dasdconv.c" />
+    <ClCompile Include="dasdcopy.c" />
+    <ClCompile Include="dasdinit.c" />
+    <ClCompile Include="dasdconv64.c" />
+    <ClCompile Include="dasdcopy64.c" />
+    <ClCompile Include="dasdinit64.c" />
+    <ClCompile Include="dasdisup.c" />
+    <ClCompile Include="dasdload.c" />
+    <ClCompile Include="dasdload64.c" />
+    <ClCompile Include="dasdls.c" />
+    <ClCompile Include="dasdpdsu.c" />
+    <ClCompile Include="dasdseq.c" />
+    <ClCompile Include="dasdtab.c" />
+    <ClCompile Include="dasdutil.c" />
+    <ClCompile Include="dasdutil64.c" />
+    <ClCompile Include="dat.c" />
+    <ClCompile Include="decimal.c" />
+    <ClCompile Include="dfp.c" />
+    <ClCompile Include="diagmssf.c" />
+    <ClCompile Include="diagnose.c" />
+    <ClCompile Include="dmap2hrc.c" />
+    <ClCompile Include="dyn76.c" />
+    <ClCompile Include="dyngui.c" />
+    <ClCompile Include="ecpsvm.c" />
+    <ClCompile Include="esame.c" />
+    <ClCompile Include="external.c" />
+    <ClCompile Include="facility.c" />
+    <ClCompile Include="faketape.c" />
+    <ClCompile Include="fbadasd.c" />
+    <ClCompile Include="fbadasd64.c" />
+    <ClCompile Include="fillfnam.c" />
+    <ClCompile Include="float.c" />
+    <ClCompile Include="fthreads.c" />
+    <ClCompile Include="ftlib.c" />
+    <ClCompile Include="general1.c" />
+    <ClCompile Include="general2.c" />
+    <ClCompile Include="general3.c" />
+    <ClCompile Include="getopt.c" />
+    <ClCompile Include="hao.c" />
+    <ClCompile Include="hchan.c" />
+    <ClCompile Include="hconsole.c" />
+    <ClCompile Include="hdiagf18.c" />
+    <ClCompile Include="hdl.c" />
+    <ClCompile Include="hdteq.c" />
+    <ClCompile Include="hercifc.c" />
+    <ClCompile Include="herclin.c" />
+    <ClCompile Include="hetget.c" />
+    <ClCompile Include="hetinit.c" />
+    <ClCompile Include="hetlib.c" />
+    <ClCompile Include="hetmap.c" />
+    <ClCompile Include="hettape.c" />
+    <ClCompile Include="hetupd.c" />
+    <ClCompile Include="hexdumpe.c" />
+    <ClCompile Include="history.c" />
+    <ClCompile Include="hostinfo.c" />
+    <ClCompile Include="hRexx.c" />
+    <ClCompile Include="hRexx_o.c" />
+    <ClCompile Include="hRexx_r.c" />
+    <ClCompile Include="hRexxapi.c" />
+    <ClCompile Include="hsccmd.c" />
+    <ClCompile Include="hscemode.c" />
+    <ClCompile Include="hscloc.c" />
+    <ClCompile Include="hscmisc.c" />
+    <ClCompile Include="hscpufun.c" />
+    <ClCompile Include="hscutl.c" />
+    <ClCompile Include="hsocket.c" />
+    <ClCompile Include="hsys.c" />
+    <ClCompile Include="hthreads.c" />
+    <ClCompile Include="httpserv.c" />
+    <ClCompile Include="ieee.c" />
+    <ClCompile Include="impl.c" />
+    <ClCompile Include="io.c" />
+    <ClCompile Include="ipl.c" />
+    <ClCompile Include="loadmem.c" />
+    <ClCompile Include="loadparm.c" />
+    <ClCompile Include="logger.c" />
+    <ClCompile Include="logmsg.c" />
+    <ClCompile Include="losc.c" />
+    <ClCompile Include="ltdl.c" />
+    <ClCompile Include="machchk.c" />
+    <ClCompile Include="maketape.c" />
+    <ClCompile Include="memrchr.c" />
+    <ClCompile Include="mpc.c" />
+    <ClCompile Include="netsupp.c" />
+    <ClCompile Include="omatape.c" />
+    <ClCompile Include="opcode.c" />
+    <ClCompile Include="panel.c" />
+    <ClCompile Include="parser.c" />
+    <ClCompile Include="pfpo.c" />
+    <ClCompile Include="plo.c" />
+    <ClCompile Include="printer.c" />
+    <ClCompile Include="pttrace.c" />
+    <ClCompile Include="qdio.c" />
+    <ClCompile Include="qeth.c" />
+    <ClCompile Include="resolve.c" />
+    <ClCompile Include="scedasd.c" />
+    <ClCompile Include="scescsi.c" />
+    <ClCompile Include="script.c" />
+    <ClCompile Include="scsitape.c" />
+    <ClCompile Include="scsiutil.c" />
+    <ClCompile Include="service.c" />
+    <ClCompile Include="shared.c" />
+    <ClCompile Include="sie.c" />
+    <ClCompile Include="sllib.c" />
+    <ClCompile Include="sockdev.c" />
+    <ClCompile Include="sr.c" />
+    <ClCompile Include="stack.c" />
+    <ClCompile Include="strsignal.c" />
+    <ClCompile Include="tapeccws.c" />
+    <ClCompile Include="tapecopy.c" />
+    <ClCompile Include="tapedev.c" />
+    <ClCompile Include="tapemap.c" />
+    <ClCompile Include="tapesplt.c" />
+    <ClCompile Include="tcpip.c" />
+    <ClCompile Include="timer.c" />
+    <ClCompile Include="trace.c" />
+    <ClCompile Include="transact.c" />
+    <ClCompile Include="tuntap.c" />
+    <ClCompile Include="vector.c" />
+    <ClCompile Include="version.c" />
+    <ClCompile Include="vm.c" />
+    <ClCompile Include="vmd250.c" />
+    <ClCompile Include="vmfplc2.c" />
+    <ClCompile Include="w32ctca.c" />
+    <ClCompile Include="w32stape.c" />
+    <ClCompile Include="w32util.c" />
+    <ClCompile Include="x75.c" />
+    <ClCompile Include="xstore.c" />
+    <ClCompile Include="zfcp.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=".travis.yml" />
+    <None Include="crypto\lib\crypto32.pdb" />
+    <None Include="crypto\lib\crypto32d.pdb" />
+    <None Include="crypto\lib\crypto64.pdb" />
+    <None Include="crypto\lib\crypto64d.pdb" />
+    <None Include="decNumber\lib\decNumber32.pdb" />
+    <None Include="decNumber\lib\decNumber32d.pdb" />
+    <None Include="decNumber\lib\decNumber64.pdb" />
+    <None Include="decNumber\lib\decNumber64d.pdb" />
+    <None Include="Hercules_VS2019.sln" />
+    <None Include="Hercules_VS2019.vcxproj" />
+    <None Include="Hercules_VS2019.vcxproj.filters" />
+    <None Include="SoftFloat\lib\SoftFloat32.pdb" />
+    <None Include="SoftFloat\lib\SoftFloat32d.pdb" />
+    <None Include="SoftFloat\lib\SoftFloat64.pdb" />
+    <None Include="SoftFloat\lib\SoftFloat64d.pdb" />
+    <None Include="telnet\lib\telnet32.pdb" />
+    <None Include="telnet\lib\telnet32d.pdb" />
+    <None Include="telnet\lib\telnet64.pdb" />
+    <None Include="telnet\lib\telnet64d.pdb" />
+    <None Include="crypto\lib\libcrypto32.a" />
+    <None Include="crypto\lib\libcrypto32d.a" />
+    <None Include="crypto\lib\libcrypto64.a" />
+    <None Include="crypto\lib\libcrypto64d.a" />
+    <None Include="decNumber\lib\libdecNumber32.a" />
+    <None Include="decNumber\lib\libdecNumber32d.a" />
+    <None Include="decNumber\lib\libdecNumber64.a" />
+    <None Include="decNumber\lib\libdecNumber64d.a" />
+    <None Include="SoftFloat\lib\libSoftFloat32.a" />
+    <None Include="SoftFloat\lib\libSoftFloat32d.a" />
+    <None Include="SoftFloat\lib\libSoftFloat64.a" />
+    <None Include="SoftFloat\lib\libSoftFloat64d.a" />
+    <None Include="telnet\lib\libtelnet32.a" />
+    <None Include="telnet\lib\libtelnet32d.a" />
+    <None Include="telnet\lib\libtelnet64.a" />
+    <None Include="telnet\lib\libtelnet64d.a" />
+    <None Include=".gitattributes" />
+    <None Include=".gitignore" />
+    <None Include="all-all.jobs" />
+    <None Include="all-all.msbuild.jobs" />
+    <None Include="autoconf\config.guess" />
+    <None Include="autoconf\config.rpath" />
+    <None Include="autoconf\config.sub" />
+    <None Include="autoconf\depcomp" />
+    <None Include="autoconf\hercules.m4" />
+    <None Include="autoconf\install-sh" />
+    <None Include="autoconf\libtool.m4" />
+    <None Include="autoconf\ltdl.m4" />
+    <None Include="autoconf\ltmain.sh" />
+    <None Include="autoconf\missing" />
+    <None Include="autoconf\mkinstalldirs" />
+    <None Include="autoconf\README" />
+    <None Include="autogen.sh" />
+    <None Include="BUILDING" />
+    <None Include="CHANGES" />
+    <None Include="configure.ac" />
+    <None Include="COPYRIGHT" />
+    <None Include="crypto\crypto.LICENSE.txt" />
+    <None Include="crypto\crypto.README.txt" />
+    <None Include="debug-all.jobs" />
+    <None Include="debug-all.msbuild.jobs" />
+    <None Include="decNumber\decnumber.pdf" />
+    <None Include="decNumber\decNumber.ERRATA" />
+    <None Include="decNumber\decNumber.ICU-license.html" />
+    <None Include="telnet\telnet.README.txt" />
+    <None Include="telnet\telnet.LICENSE.txt" />
+    <None Include="dynmake.bat" />
+    <None Include="hercules.cnf" />
+    <None Include="hercules.cnf.rexx" />
+    <None Include="Hercules_VS2008.sln" />
+    <None Include="Hercules_VS2008.vcproj" />
+    <None Include="Hercules_VS2015.sln" />
+    <None Include="Hercules_VS2015.vcxproj" />
+    <None Include="Hercules_VS2015.vcxproj.filters" />
+    <None Include="hercver.rc2" />
+    <None Include="html\cckddasd.html" />
+    <None Include="html\fishgui.html" />
+    <None Include="html\hercconf.html" />
+    <None Include="html\hercfaq.html" />
+    <None Include="html\hercinst.html" />
+    <None Include="html\herclic.html" />
+    <None Include="html\hercload.html" />
+    <None Include="html\hercmsca.html" />
+    <None Include="html\hercmscf.html" />
+    <None Include="html\hercmscp.html" />
+    <None Include="html\hercmsct.html" />
+    <None Include="html\hercmscu.html" />
+    <None Include="html\hercmsda.html" />
+    <None Include="html\hercmsdc.html" />
+    <None Include="html\hercmsdg.html" />
+    <None Include="html\hercmsdi.html" />
+    <None Include="html\hercmsdl.html" />
+    <None Include="html\hercmsdn.html" />
+    <None Include="html\hercmsds.html" />
+    <None Include="html\hercmsdt.html" />
+    <None Include="html\hercmsdu.html" />
+    <None Include="html\hercmsg.html" />
+    <None Include="html\hercmshd.html" />
+    <None Include="html\hercmshe.html" />
+    <None Include="html\hercmshg.html" />
+    <None Include="html\hercmshm.html" />
+    <None Include="html\hercmsht.html" />
+    <None Include="html\hercmshu.html" />
+    <None Include="html\hercmsif.html" />
+    <None Include="html\hercmsin.html" />
+    <None Include="html\hercmslc.html" />
+    <None Include="html\hercmslg.html" />
+    <None Include="html\hercmspn.html" />
+    <None Include="html\hercmspr.html" />
+    <None Include="html\hercmspu.html" />
+    <None Include="html\hercmsrd.html" />
+    <None Include="html\hercmssd.html" />
+    <None Include="html\hercmsta.html" />
+    <None Include="html\hercmstc.html" />
+    <None Include="html\hercmste.html" />
+    <None Include="html\hercmstm.html" />
+    <None Include="html\hercmsts.html" />
+    <None Include="html\hercmstt.html" />
+    <None Include="html\hercmstu.html" />
+    <None Include="html\hercmsvm.html" />
+    <None Include="html\hercnew.html" />
+    <None Include="html\hercrdr.html" />
+    <None Include="html\hercrnot.html" />
+    <None Include="html\hercsupp.html" />
+    <None Include="html\herctcp.html" />
+    <None Include="html\hercules.css" />
+    <None Include="html\hercules.html" />
+    <None Include="html\include\footer.htmlpart" />
+    <None Include="html\include\header.htmlpart" />
+    <None Include="html\index.html" />
+    <None Include="html\Makefile.am" />
+    <None Include="html\rexx.html" />
+    <None Include="html\shared.html" />
+    <None Include="html\tasks.html" />
+    <None Include="html\telnet.html" />
+    <None Include="INSTALL" />
+    <None Include="m4\ChangeLog" />
+    <None Include="m4\codeset.m4" />
+    <None Include="m4\gettext.m4" />
+    <None Include="m4\glibc2.m4" />
+    <None Include="m4\glibc21.m4" />
+    <None Include="m4\iconv.m4" />
+    <None Include="m4\intdiv0.m4" />
+    <None Include="m4\intmax.m4" />
+    <None Include="m4\inttypes-pri.m4" />
+    <None Include="m4\inttypes.m4" />
+    <None Include="m4\inttypes_h.m4" />
+    <None Include="m4\isc-posix.m4" />
+    <None Include="m4\lcmessage.m4" />
+    <None Include="m4\lib-ld.m4" />
+    <None Include="m4\lib-link.m4" />
+    <None Include="m4\lib-prefix.m4" />
+    <None Include="m4\longdouble.m4" />
+    <None Include="m4\longlong.m4" />
+    <None Include="m4\Makefile.am" />
+    <None Include="m4\nls.m4" />
+    <None Include="m4\po.m4" />
+    <None Include="m4\printf-posix.m4" />
+    <None Include="m4\progtest.m4" />
+    <None Include="m4\signed.m4" />
+    <None Include="m4\size_max.m4" />
+    <None Include="m4\stdint_h.m4" />
+    <None Include="m4\uintmax_t.m4" />
+    <None Include="m4\ulonglong.m4" />
+    <None Include="m4\wchar_t.m4" />
+    <None Include="m4\wint_t.m4" />
+    <None Include="m4\xsize.m4" />
+    <None Include="makefile-dllmod.msvc" />
+    <None Include="Makefile.am" />
+    <None Include="makefile.bat" />
+    <None Include="makefile.msvc" />
+    <None Include="man\cckd.4" />
+    <None Include="man\cckddiag.1" />
+    <None Include="man\dasdseq.1" />
+    <None Include="man\Makefile.am" />
+    <None Include="man\vmfplc2.1" />
+    <None Include="msvc.makefile.includes\BZIP2_DIR.msvc" />
+    <None Include="msvc.makefile.includes\BZIP2_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\BZIP2_RULES.msvc" />
+    <None Include="msvc.makefile.includes\CONFIG.msvc" />
+    <None Include="msvc.makefile.includes\DEBUG_RETAIL.msvc" />
+    <None Include="msvc.makefile.includes\EXT_PKGS.msvc" />
+    <None Include="msvc.makefile.includes\HERC_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\HQA_DIR.msvc" />
+    <None Include="msvc.makefile.includes\HQA_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\IPV6_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\MODULES.msvc" />
+    <None Include="msvc.makefile.includes\MOD_RULES1.msvc" />
+    <None Include="msvc.makefile.includes\MOD_RULES2.msvc" />
+    <None Include="msvc.makefile.includes\OBJ_CODE.msvc" />
+    <None Include="msvc.makefile.includes\OUTDIR_RULES.msvc" />
+    <None Include="msvc.makefile.includes\OUTPUT_DIRS.msvc" />
+    <None Include="msvc.makefile.includes\PCRE_DIR.msvc" />
+    <None Include="msvc.makefile.includes\PCRE_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\PCRE_RULES.msvc" />
+    <None Include="msvc.makefile.includes\PRIM_RULES.msvc" />
+    <None Include="msvc.makefile.includes\REXX_DIRS.msvc" />
+    <None Include="msvc.makefile.includes\REXX_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\REXX_RULES.msvc" />
+    <None Include="msvc.makefile.includes\TARGETVER.msvc" />
+    <None Include="msvc.makefile.includes\VERSION.msvc" />
+    <None Include="msvc.makefile.includes\VSVERS.msvc" />
+    <None Include="msvc.makefile.includes\ZLIB_DIR.msvc" />
+    <None Include="msvc.makefile.includes\ZLIB_FLAGS.msvc" />
+    <None Include="msvc.makefile.includes\ZLIB_RULES.msvc" />
+    <None Include="README.AIX" />
+    <None Include="README.APL360" />
+    <None Include="README.BSD" />
+    <None Include="README.CCKD64" />
+    <None Include="README.CMPSC" />
+    <None Include="README.COMMADPT" />
+    <None Include="README.DYNMOD" />
+    <None Include="README.ECPSVM" />
+    <None Include="README.EXTPKG" />
+    <None Include="README.HAO" />
+    <None Include="README.HDL" />
+    <None Include="README.HERCLOGO" />
+    <None Include="README.HQA" />
+    <None Include="README.HRAF" />
+    <None Include="README.IOARCH" />
+    <None Include="README.ISSUES" />
+    <None Include="README.md" />
+    <None Include="README.MINGW" />
+    <None Include="README.MSVC" />
+    <None Include="README.NETWORKING" />
+    <None Include="README.OSX" />
+    <None Include="README.PTT" />
+    <None Include="README.REXX" />
+    <None Include="README.RUNTEST" />
+    <None Include="README.RXVT4APL" />
+    <None Include="README.S37X" />
+    <None Include="README.SETUID" />
+    <None Include="README.SUN" />
+    <None Include="README.TAPE" />
+    <None Include="README.TCPIP" />
+    <None Include="README.VMFPLC2" />
+    <None Include="README.WIN64" />
+    <None Include="RELEASE.NOTES" />
+    <None Include="retail-all.jobs" />
+    <None Include="retail-all.msbuild.jobs" />
+    <None Include="scripts\cmpsc.cnf" />
+    <None Include="scripts\cmpsc.rexx" />
+    <None Include="scripts\hbasic1.rexx" />
+    <None Include="scripts\hbasic2.rex" />
+    <None Include="scripts\hbasic3.cmd" />
+    <None Include="scripts\hbasic4.rx" />
+    <None Include="scripts\hbasic5.ext1" />
+    <None Include="scripts\hbasics" />
+    <None Include="scripts\hcommand.rexx" />
+    <None Include="scripts\hexecio.rexx" />
+    <None Include="scripts\hlinein.rexx" />
+    <None Include="scripts\hrecurs.rexx" />
+    <None Include="SoftFloat\doc\SoftFloat-history.html" />
+    <None Include="SoftFloat\doc\SoftFloat-source.html" />
+    <None Include="SoftFloat\doc\SoftFloat.html" />
+    <None Include="SoftFloat\softfloat.README.html" />
+    <None Include="tests\1403.tst" />
+    <None Include="tests\3211.asm" />
+    <None Include="tests\3211.core" />
+    <None Include="tests\3211.list" />
+    <None Include="tests\3211.pdf" />
+    <None Include="tests\3211.rexx" />
+    <None Include="tests\3211.tst" />
+    <None Include="tests\agf.assemble" />
+    <None Include="tests\agf.listing" />
+    <None Include="tests\agf.tst" />
+    <None Include="tests\awsbsf.aws" />
+    <None Include="tests\awsbsf.tst" />
+    <None Include="tests\bfp-001-divtoint.asm" />
+    <None Include="tests\bfp-001-divtoint.core" />
+    <None Include="tests\bfp-001-divtoint.list" />
+    <None Include="tests\bfp-001-divtoint.tst" />
+    <None Include="tests\bfp-002-loadr.asm" />
+    <None Include="tests\bfp-002-loadr.core" />
+    <None Include="tests\bfp-002-loadr.list" />
+    <None Include="tests\bfp-002-loadr.tst" />
+    <None Include="tests\bfp-003-loadfpi.asm" />
+    <None Include="tests\bfp-003-loadfpi.core" />
+    <None Include="tests\bfp-003-loadfpi.list" />
+    <None Include="tests\bfp-003-loadfpi.tst" />
+    <None Include="tests\bfp-004-cvttolog.asm" />
+    <None Include="tests\bfp-004-cvttolog.core" />
+    <None Include="tests\bfp-004-cvttolog.list" />
+    <None Include="tests\bfp-004-cvttolog.tst" />
+    <None Include="tests\bfp-005-cvttolog64.asm" />
+    <None Include="tests\bfp-005-cvttolog64.core" />
+    <None Include="tests\bfp-005-cvttolog64.list" />
+    <None Include="tests\bfp-005-cvttolog64.tst" />
+    <None Include="tests\bfp-006-cvttofix.asm" />
+    <None Include="tests\bfp-006-cvttofix.core" />
+    <None Include="tests\bfp-006-cvttofix.list" />
+    <None Include="tests\bfp-006-cvttofix.tst" />
+    <None Include="tests\bfp-007-cvttofix64.asm" />
+    <None Include="tests\bfp-007-cvttofix64.core" />
+    <None Include="tests\bfp-007-cvttofix64.list" />
+    <None Include="tests\bfp-007-cvttofix64.tst" />
+    <None Include="tests\bfp-008-cvtfrlog.asm" />
+    <None Include="tests\bfp-008-cvtfrlog.core" />
+    <None Include="tests\bfp-008-cvtfrlog.list" />
+    <None Include="tests\bfp-008-cvtfrlog.tst" />
+    <None Include="tests\bfp-009-cvtfrlog64.asm" />
+    <None Include="tests\bfp-009-cvtfrlog64.core" />
+    <None Include="tests\bfp-009-cvtfrlog64.list" />
+    <None Include="tests\bfp-009-cvtfrlog64.tst" />
+    <None Include="tests\bfp-010-cvtfrfix.asm" />
+    <None Include="tests\bfp-010-cvtfrfix.core" />
+    <None Include="tests\bfp-010-cvtfrfix.list" />
+    <None Include="tests\bfp-010-cvtfrfix.tst" />
+    <None Include="tests\bfp-011-cvtfrfix64.asm" />
+    <None Include="tests\bfp-011-cvtfrfix64.core" />
+    <None Include="tests\bfp-011-cvtfrfix64.list" />
+    <None Include="tests\bfp-011-cvtfrfix64.tst" />
+    <None Include="tests\bfp-012-loadtest.asm" />
+    <None Include="tests\bfp-012-loadtest.core" />
+    <None Include="tests\bfp-012-loadtest.list" />
+    <None Include="tests\bfp-012-loadtest.tst" />
+    <None Include="tests\bfp-013-comps.asm" />
+    <None Include="tests\bfp-013-comps.core" />
+    <None Include="tests\bfp-013-comps.list" />
+    <None Include="tests\bfp-013-comps.tst" />
+    <None Include="tests\bfp-014-divide.asm" />
+    <None Include="tests\bfp-014-divide.core" />
+    <None Include="tests\bfp-014-divide.list" />
+    <None Include="tests\bfp-014-divide.tst" />
+    <None Include="tests\bfp-015-sqrt.asm" />
+    <None Include="tests\bfp-015-sqrt.core" />
+    <None Include="tests\bfp-015-sqrt.list" />
+    <None Include="tests\bfp-015-sqrt.tst" />
+    <None Include="tests\bfp-016-add.asm" />
+    <None Include="tests\bfp-016-add.core" />
+    <None Include="tests\bfp-016-add.list" />
+    <None Include="tests\bfp-016-add.tst" />
+    <None Include="tests\bfp-017-loadl.asm" />
+    <None Include="tests\bfp-017-loadl.core" />
+    <None Include="tests\bfp-017-loadl.list" />
+    <None Include="tests\bfp-017-loadl.tst" />
+    <None Include="tests\bfp-018-subtract.asm" />
+    <None Include="tests\bfp-018-subtract.core" />
+    <None Include="tests\bfp-018-subtract.list" />
+    <None Include="tests\bfp-018-subtract.tst" />
+    <None Include="tests\bfp-019-multiply.asm" />
+    <None Include="tests\bfp-019-multiply.core" />
+    <None Include="tests\bfp-019-multiply.list" />
+    <None Include="tests\bfp-019-multiply.tst" />
+    <None Include="tests\bfp-020-multlonger.asm" />
+    <None Include="tests\bfp-020-multlonger.core" />
+    <None Include="tests\bfp-020-multlonger.list" />
+    <None Include="tests\bfp-020-multlonger.tst" />
+    <None Include="tests\bfp-021-multadd.asm" />
+    <None Include="tests\bfp-021-multadd.core" />
+    <None Include="tests\bfp-021-multadd.list" />
+    <None Include="tests\bfp-021-multadd.tst" />
+    <None Include="tests\bfp-022-multsub.asm" />
+    <None Include="tests\bfp-022-multsub.core" />
+    <None Include="tests\bfp-022-multsub.list" />
+    <None Include="tests\bfp-022-multsub.tst" />
+    <None Include="tests\bfp-023-threads.asm" />
+    <None Include="tests\bfp-023-threads.core" />
+    <None Include="tests\bfp-023-threads.list" />
+    <None Include="tests\bfp-023-threads.sptst" />
+    <None Include="tests\bim-001-add-sub.asm" />
+    <None Include="tests\bim-001-add-sub.core" />
+    <None Include="tests\bim-001-add-sub.list" />
+    <None Include="tests\bim-001-add-sub.tst" />
+    <None Include="tests\CBUC.asm" />
+    <None Include="tests\CBUC.core" />
+    <None Include="tests\CBUC.list" />
+    <None Include="tests\CBUC.pdf" />
+    <None Include="tests\CBUC.subtst" />
+    <None Include="tests\CBUC.tst" />
+    <None Include="tests\CCW-ILS.asm" />
+    <None Include="tests\CCWILS.3390-1.comp-z" />
+    <None Include="tests\CCW-ILS.core" />
+    <None Include="tests\CCW-ILS.list" />
+    <None Include="tests\CCW-ILS.pdf" />
+    <None Include="tests\CCW-ILS.tst" />
+    <None Include="tests\CLCL-et-al.asm" />
+    <None Include="tests\CLCL-et-al.core" />
+    <None Include="tests\CLCL-et-al.list" />
+    <None Include="tests\CLCL-et-al.pdf" />
+    <None Include="tests\CLCL-et-al.tst" />
+    <None Include="tests\CLCL.asm" />
+    <None Include="tests\CLCL.core" />
+    <None Include="tests\CLCL.list" />
+    <None Include="tests\CLCL.pdf" />
+    <None Include="tests\CLCL.tst" />
+    <None Include="tests\cipher.assemble" />
+    <None Include="tests\cipher.listing" />
+    <None Include="tests\cipher.tst" />
+    <None Include="tests\cmd-abs-2K.subtst" />
+    <None Include="tests\cmd-abs-4K.subtst" />
+    <None Include="tests\cmd-abs.tst" />
+    <None Include="tests\cmd-rv-2K.subtst" />
+    <None Include="tests\cmd-rv-4K-32.subtst" />
+    <None Include="tests\cmd-rv-4K-64.subtst" />
+    <None Include="tests\cmd-rv.tst" />
+    <None Include="tests\cr.tst" />
+    <None Include="tests\cpu0off.core" />
+    <None Include="tests\dotest" />
+    <None Include="tests\FAC53.asm" />
+    <None Include="tests\FAC53.core" />
+    <None Include="tests\FAC53.list" />
+    <None Include="tests\FAC53.pdf" />
+    <None Include="tests\FAC53.tst" />
+    <None Include="tests\csxtr.assemble" />
+    <None Include="tests\csxtr.listing" />
+    <None Include="tests\csxtr.tst" />
+    <None Include="tests\dc-float.asm" />
+    <None Include="tests\digest.assemble" />
+    <None Include="tests\digest.listing" />
+    <None Include="tests\digest.tst" />
+    <None Include="tests\dummy.subtst" />
+    <None Include="tests\hetbsf-bzip2.het" />
+    <None Include="tests\hetbsf.het" />
+    <None Include="tests\hetbsf.tst" />
+    <None Include="tests\ifelse.tst" />
+    <None Include="tests\ilc.assemble" />
+    <None Include="tests\ilc.listing" />
+    <None Include="tests\ilc.tst" />
+    <None Include="tests\invpsw.assemble" />
+    <None Include="tests\invpsw.listing" />
+    <None Include="tests\invpsw.tst" />
+    <None Include="tests\kimd-hw.tst" />
+    <None Include="tests\klmd-hw.tst" />
+    <None Include="tests\km-hw.tst" />
+    <None Include="tests\kmac-hw.tst" />
+    <None Include="tests\kmc-hw.tst" />
+    <None Include="tests\kmctr-hw.tst" />
+    <None Include="tests\kmf-hw.tst" />
+    <None Include="tests\kmo-hw.tst" />
+    <None Include="tests\leapfrog.assemble" />
+    <None Include="tests\leapfrog.listing" />
+    <None Include="tests\leapfrog.tst" />
+    <None Include="tests\logicimm.assemble" />
+    <None Include="tests\logicimm.listing" />
+    <None Include="tests\logicimm.tst" />
+    <None Include="tests\mainsize.tst" />
+    <None Include="tests\Makefile.am" />
+    <None Include="tests\mhi.asm" />
+    <None Include="tests\mhi.core" />
+    <None Include="tests\mhi.list" />
+    <None Include="tests\mhi.tst" />
+    <None Include="tests\mkcore.rexx" />
+    <None Include="tests\mvcle.assemble" />
+    <None Include="tests\mvcle.listing" />
+    <None Include="tests\mvcle.tst" />
+    <None Include="tests\pfpo.asm" />
+    <None Include="tests\pfpo.core" />
+    <None Include="tests\pfpo.list" />
+    <None Include="tests\PFPO.pdf" />
+    <None Include="tests\pfpo.tst" />
+    <None Include="tests\pr.subtst" />
+    <None Include="tests\pr.tst" />
+    <None Include="tests\privop.asm" />
+    <None Include="tests\privop.core" />
+    <None Include="tests\privop.list" />
+    <None Include="tests\privop.tst" />
+    <None Include="tests\problem.asm" />
+    <None Include="tests\problem.core" />
+    <None Include="tests\problem.list" />
+    <None Include="tests\problem.tst" />
+    <None Include="tests\README" />
+    <None Include="tests\redtest.rexx" />
+    <None Include="tests\runtest" />
+    <None Include="tests\runtest.cmd" />
+    <None Include="tests\runtest.subtst" />
+    <None Include="tests\stidp-esa390.subtst" />
+    <None Include="tests\stidp-s370.subtst" />
+    <None Include="tests\stidp-zarch.subtst" />
+    <None Include="tests\runtest0.tst" />
+    <None Include="tests\runtest4.tst" />
+    <None Include="tests\semipriv.asm" />
+    <None Include="tests\semipriv.core" />
+    <None Include="tests\semipriv.list" />
+    <None Include="tests\semipriv.tst" />
+    <None Include="tests\sigp.assemble" />
+    <None Include="tests\sigp.listing" />
+    <None Include="tests\sigp.tst" />
+    <None Include="tests\ssk370.tst" />
+    <None Include="tests\sske.assemble" />
+    <None Include="tests\sske.listing" />
+    <None Include="tests\sske.tst" />
+    <None Include="tests\sske370.tst" />
+    <None Include="tests\sske390.tst" />
+    <None Include="tests\stfl.asm" />
+    <None Include="tests\stfl.core" />
+    <None Include="tests\stfl.list" />
+    <None Include="tests\stfl.tst" />
+    <None Include="tests\str-001-cksm.asm" />
+    <None Include="tests\str-001-cksm.core" />
+    <None Include="tests\str-001-cksm.list" />
+    <None Include="tests\str-001-cksm.tst" />
+    <None Include="tests\str-001-clst.asm" />
+    <None Include="tests\str-001-clst.core" />
+    <None Include="tests\str-001-clst.list" />
+    <None Include="tests\str-001-clst.tst" />
+    <None Include="tests\str-001-mvst.asm" />
+    <None Include="tests\str-001-mvst.core" />
+    <None Include="tests\str-001-mvst.list" />
+    <None Include="tests\str-001-mvst.tst" />
+    <None Include="tests\str-001-srst.asm" />
+    <None Include="tests\str-001-srst.core" />
+    <None Include="tests\str-001-srst.list" />
+    <None Include="tests\str-001-srst.tst" />
+    <None Include="tests\stidp.tst" />
+    <None Include="tests\tape.asm" />
+    <None Include="tests\tape.aws" />
+    <None Include="tests\tape.core" />
+    <None Include="tests\tape.list" />
+    <None Include="tests\tape.pdf" />
+    <None Include="tests\tape.tst" />
+    <None Include="tests\tapebsf.subtst" />
+    <None Include="tests\tests.conf" />
+    <None Include="tests\text2tst.rexx" />
+    <None Include="tests\timeout.tst" />
+    <None Include="tests\wild.assemble" />
+    <None Include="tests\wild.listing" />
+    <None Include="tests\wild.tst" />
+    <None Include="tests\zeos.assemble" />
+    <None Include="tests\zeos.listing" />
+    <None Include="tests\zeos.tst" />
+    <None Include="util\awssl-v19g" />
+    <None Include="util\awswrite.jcl" />
+    <None Include="util\bldlvlck" />
+    <None Include="util\cckddump.hla" />
+    <None Include="util\cckdload.hla" />
+    <None Include="util\configure.ac" />
+    <None Include="util\dasdlist" />
+    <None Include="util\dasdlist.bat" />
+    <None Include="util\Makefile.am" />
+    <None Include="util\rawstape.jcl" />
+    <None Include="util\scsiboot" />
+    <None Include="util\tapeconv.jcl" />
+    <None Include="util\voldsext.cmd" />
+    <None Include="util\zzsacard.bin" />
+    <None Include="vstools.cmd" />
+    <None Include="_dynamic_version" />
+    <None Include="_dynamic_version.cmd" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="archlvl.h" />
+    <ClInclude Include="cache.h" />
+    <ClInclude Include="ccfixme.h" />
+    <ClInclude Include="cckd.h" />
+    <ClInclude Include="cckd64.h" />
+    <ClInclude Include="cckddasd.h" />
+    <ClInclude Include="ccnowarn.h" />
+    <ClInclude Include="ccwarn.h" />
+    <ClInclude Include="chain.h" />
+    <ClInclude Include="chsc.h" />
+    <ClInclude Include="clock.h" />
+    <ClInclude Include="cmdtab.h" />
+    <ClInclude Include="cmpsc.h" />
+    <ClInclude Include="cmpscbit.h" />
+    <ClInclude Include="cmpscdbg.h" />
+    <ClInclude Include="cmpscdct.h" />
+    <ClInclude Include="cmpscget.h" />
+    <ClInclude Include="cmpscmem.h" />
+    <ClInclude Include="cmpscput.h" />
+    <ClInclude Include="cnsllogo.h" />
+    <ClInclude Include="codepage.h" />
+    <ClInclude Include="comm3705.h" />
+    <ClInclude Include="commadpt.h" />
+    <ClInclude Include="cpuint.h" />
+    <ClInclude Include="crypto\include\crypto.h" />
+    <ClInclude Include="crypto\include\crypto_version.h" />
+    <ClInclude Include="crypto\include\rijndael.h" />
+    <ClInclude Include="crypto\include\sha1.h" />
+    <ClInclude Include="crypto\include\sha2.h" />
+    <ClInclude Include="crypto\include\sshdes.h" />
+    <ClInclude Include="ctc_ptp.h" />
+    <ClInclude Include="ctcadpt.h" />
+    <ClInclude Include="dasdblks.h" />
+    <ClInclude Include="dasdtab.h" />
+    <ClInclude Include="dat.h" />
+    <ClInclude Include="dbgtrace.h" />
+    <ClInclude Include="decNumber\include\decContext.h" />
+    <ClInclude Include="decNumber\include\decimal128.h" />
+    <ClInclude Include="decNumber\include\decimal32.h" />
+    <ClInclude Include="decNumber\include\decimal64.h" />
+    <ClInclude Include="decNumber\include\decNumber.h" />
+    <ClInclude Include="decNumber\include\decnumber_version.h" />
+    <ClInclude Include="decNumber\include\decPacked.h" />
+    <ClInclude Include="decNumber\include\decQuad.h" />
+    <ClInclude Include="telnet\include\telnet.h" />
+    <ClInclude Include="telnet\include\telnet_version.h" />
+    <ClInclude Include="devtype.h" />
+    <ClInclude Include="ecpsvm.h" />
+    <ClInclude Include="esa390.h" />
+    <ClInclude Include="esa390io.h" />
+    <ClInclude Include="extstring.h" />
+    <ClInclude Include="facility.h" />
+    <ClInclude Include="feat370.h" />
+    <ClInclude Include="feat390.h" />
+    <ClInclude Include="feat900.h" />
+    <ClInclude Include="featall.h" />
+    <ClInclude Include="featchk.h" />
+    <ClInclude Include="feature.h" />
+    <ClInclude Include="fillfnam.h" />
+    <ClInclude Include="fthreads.h" />
+    <ClInclude Include="ftlib.h" />
+    <ClInclude Include="getopt.h" />
+    <ClInclude Include="hatomic.h" />
+    <ClInclude Include="hbyteswp.h" />
+    <ClInclude Include="hchan.h" />
+    <ClInclude Include="hconsole.h" />
+    <ClInclude Include="hconsts.h" />
+    <ClInclude Include="hcrypto.h" />
+    <ClInclude Include="hdiagf18.h" />
+    <ClInclude Include="hdl.h" />
+    <ClInclude Include="hercifc.h" />
+    <ClInclude Include="hercules.h" />
+    <ClInclude Include="hercwind.h" />
+    <ClInclude Include="herc_getopt.h" />
+    <ClInclude Include="herror.h" />
+    <ClInclude Include="hetlib.h" />
+    <ClInclude Include="hexdumpe.h" />
+    <ClInclude Include="hexterns.h" />
+    <ClInclude Include="hifr.h" />
+    <ClInclude Include="hinlines.h" />
+    <ClInclude Include="history.h" />
+    <ClInclude Include="hmacros.h" />
+    <ClInclude Include="hmalloc.h" />
+    <ClInclude Include="hostinfo.h" />
+    <ClInclude Include="hostopts.h" />
+    <ClInclude Include="hqadefs.h" />
+    <ClInclude Include="hqainc.h" />
+    <ClInclude Include="hqawarn.h" />
+    <ClInclude Include="hRexx.h" />
+    <ClInclude Include="hscutl.h" />
+    <ClInclude Include="hsocket.h" />
+    <ClInclude Include="hstdinc.h" />
+    <ClInclude Include="hstructs.h" />
+    <ClInclude Include="hthreads.h" />
+    <ClInclude Include="httpmisc.h" />
+    <ClInclude Include="htypes.h" />
+    <ClInclude Include="impexp.h" />
+    <ClInclude Include="inline.h" />
+    <ClInclude Include="linklist.h" />
+    <ClInclude Include="logger.h" />
+    <ClInclude Include="ltdl.h" />
+    <ClInclude Include="machdep.h" />
+    <ClInclude Include="memrchr.h" />
+    <ClInclude Include="mpc.h" />
+    <ClInclude Include="msgenu.h" />
+    <ClInclude Include="netsupp.h" />
+    <ClInclude Include="opcode.h" />
+    <ClInclude Include="parser.h" />
+    <ClInclude Include="printfmt.h" />
+    <ClInclude Include="pttrace.h" />
+    <ClInclude Include="qdio.h" />
+    <ClInclude Include="qeth.h" />
+    <ClInclude Include="resolve.h" />
+    <ClInclude Include="scsitape.h" />
+    <ClInclude Include="scsiutil.h" />
+    <ClInclude Include="service.h" />
+    <ClInclude Include="shared.h" />
+    <ClInclude Include="sllib.h" />
+    <ClInclude Include="sockdev.h" />
+    <ClInclude Include="SoftFloat\include\softfloat.h" />
+    <ClInclude Include="SoftFloat\include\softfloat_version.h" />
+    <ClInclude Include="SoftFloat\include\softfloat_types.h" />
+    <ClInclude Include="sr.h" />
+    <ClInclude Include="stfl.h" />
+    <ClInclude Include="tapedev.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="tcpip.h" />
+    <ClInclude Include="tt32api.h" />
+    <ClInclude Include="tt32if.h" />
+    <ClInclude Include="tuntap.h" />
+    <ClInclude Include="version.h" />
+    <ClInclude Include="vmd250.h" />
+    <ClInclude Include="vstore.h" />
+    <ClInclude Include="vsvers.h" />
+    <ClInclude Include="w32ctca.h" />
+    <ClInclude Include="w32dl.h" />
+    <ClInclude Include="w32mtio.h" />
+    <ClInclude Include="w32stape.h" />
+    <ClInclude Include="w32util.h" />
+    <ClInclude Include="x75.h" />
+    <ClInclude Include="zfcp.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="decNumber\decNumber.readme.txt" />
+    <Text Include="herclogo.txt" />
+    <Text Include="license_dyn76.txt" />
+    <Text Include="SoftFloat\softfloat.LICENSE.txt" />
+    <Text Include="SoftFloat\softfloat.README.txt" />
+    <Text Include="tests\alsi.txt" />
+    <Text Include="tests\axtr.txt" />
+    <Text Include="tests\brc.txt" />
+    <Text Include="tests\cdfr.txt" />
+    <Text Include="tests\cdgr.txt" />
+    <Text Include="tests\cdsg.txt" />
+    <Text Include="tests\cgdr.txt" />
+    <Text Include="tests\cgdtr.txt" />
+    <Text Include="tests\cger.txt" />
+    <Text Include="tests\cgfrl.txt" />
+    <Text Include="tests\cgxr.txt" />
+    <Text Include="tests\cgxtr.txt" />
+    <Text Include="tests\channel-370.txt" />
+    <Text Include="tests\comments.txt" />
+    <Text Include="tests\cpsdr.txt" />
+    <Text Include="tests\csst.txt" />
+    <Text Include="tests\cxgbr.txt" />
+    <Text Include="tests\cxgtr.txt" />
+    <Text Include="tests\diag24.txt" />
+    <Text Include="tests\diag8.txt" />
+    <Text Include="tests\dxtr.txt" />
+    <Text Include="tests\epsw.txt" />
+    <Text Include="tests\exrl.txt" />
+    <Text Include="tests\fiebr.txt" />
+    <Text Include="tests\fixtr.txt" />
+    <Text Include="tests\iedtr.txt" />
+    <Text Include="tests\kimd0.txt" />
+    <Text Include="tests\kimd1.txt" />
+    <Text Include="tests\kimd2.txt" />
+    <Text Include="tests\kimd3.txt" />
+    <Text Include="tests\kimd65.txt" />
+    <Text Include="tests\klmd0.txt" />
+    <Text Include="tests\klmd1.txt" />
+    <Text Include="tests\klmd2.txt" />
+    <Text Include="tests\klmd3.txt" />
+    <Text Include="tests\km0.txt" />
+    <Text Include="tests\km1.txt" />
+    <Text Include="tests\km10.txt" />
+    <Text Include="tests\km11.txt" />
+    <Text Include="tests\km18.txt" />
+    <Text Include="tests\km19.txt" />
+    <Text Include="tests\km2.txt" />
+    <Text Include="tests\km20.txt" />
+    <Text Include="tests\km26.txt" />
+    <Text Include="tests\km27.txt" />
+    <Text Include="tests\km28.txt" />
+    <Text Include="tests\km3.txt" />
+    <Text Include="tests\km50.txt" />
+    <Text Include="tests\km52.txt" />
+    <Text Include="tests\km58.txt" />
+    <Text Include="tests\km60.txt" />
+    <Text Include="tests\km9.txt" />
+    <Text Include="tests\kmac0.txt" />
+    <Text Include="tests\kmac1.txt" />
+    <Text Include="tests\kmac10.txt" />
+    <Text Include="tests\kmac11.txt" />
+    <Text Include="tests\kmac18.txt" />
+    <Text Include="tests\kmac19.txt" />
+    <Text Include="tests\kmac2.txt" />
+    <Text Include="tests\kmac20.txt" />
+    <Text Include="tests\kmac26.txt" />
+    <Text Include="tests\kmac27.txt" />
+    <Text Include="tests\kmac28.txt" />
+    <Text Include="tests\kmac3.txt" />
+    <Text Include="tests\kmac9.txt" />
+    <Text Include="tests\kmc0.txt" />
+    <Text Include="tests\kmc1.txt" />
+    <Text Include="tests\kmc10.txt" />
+    <Text Include="tests\kmc11.txt" />
+    <Text Include="tests\kmc18.txt" />
+    <Text Include="tests\kmc19.txt" />
+    <Text Include="tests\kmc2.txt" />
+    <Text Include="tests\kmc20.txt" />
+    <Text Include="tests\kmc26.txt" />
+    <Text Include="tests\kmc27.txt" />
+    <Text Include="tests\kmc28.txt" />
+    <Text Include="tests\kmc3.txt" />
+    <Text Include="tests\kmc67.txt" />
+    <Text Include="tests\kmc9.txt" />
+    <Text Include="tests\kmctr0.txt" />
+    <Text Include="tests\kmctr1.txt" />
+    <Text Include="tests\kmctr10.txt" />
+    <Text Include="tests\kmctr11.txt" />
+    <Text Include="tests\kmctr18.txt" />
+    <Text Include="tests\kmctr19.txt" />
+    <Text Include="tests\kmctr2.txt" />
+    <Text Include="tests\kmctr20.txt" />
+    <Text Include="tests\kmctr26.txt" />
+    <Text Include="tests\kmctr27.txt" />
+    <Text Include="tests\kmctr28.txt" />
+    <Text Include="tests\kmctr3.txt" />
+    <Text Include="tests\kmctr9.txt" />
+    <Text Include="tests\kmf0.txt" />
+    <Text Include="tests\kmf1.txt" />
+    <Text Include="tests\kmf10.txt" />
+    <Text Include="tests\kmf11.txt" />
+    <Text Include="tests\kmf18.txt" />
+    <Text Include="tests\kmf19.txt" />
+    <Text Include="tests\kmf2.txt" />
+    <Text Include="tests\kmf20.txt" />
+    <Text Include="tests\kmf26.txt" />
+    <Text Include="tests\kmf27.txt" />
+    <Text Include="tests\kmf28.txt" />
+    <Text Include="tests\kmf3.txt" />
+    <Text Include="tests\kmf9.txt" />
+    <Text Include="tests\kmo0.txt" />
+    <Text Include="tests\kmo1.txt" />
+    <Text Include="tests\kmo10.txt" />
+    <Text Include="tests\kmo11.txt" />
+    <Text Include="tests\kmo18.txt" />
+    <Text Include="tests\kmo19.txt" />
+    <Text Include="tests\kmo2.txt" />
+    <Text Include="tests\kmo20.txt" />
+    <Text Include="tests\kmo26.txt" />
+    <Text Include="tests\kmo27.txt" />
+    <Text Include="tests\kmo28.txt" />
+    <Text Include="tests\kmo3.txt" />
+    <Text Include="tests\kmo9.txt" />
+    <Text Include="tests\ldetr.txt" />
+    <Text Include="tests\ldxtr.txt" />
+    <Text Include="tests\ledtr.txt" />
+    <Text Include="tests\lfpc.txt" />
+    <Text Include="tests\llhrl.txt" />
+    <Text Include="tests\locgr.txt" />
+    <Text Include="tests\loop.txt" />
+    <Text Include="tests\lparnum.txt" />
+    <Text Include="tests\lpp.txt" />
+    <Text Include="tests\lxdtr.txt" />
+    <Text Include="tests\maer.txt" />
+    <Text Include="tests\mvcos.txt" />
+    <Text Include="tests\mxtr.txt" />
+    <Text Include="tests\popcnt.txt" />
+    <Text Include="tests\printer.txt" />
+    <Text Include="tests\ptf.txt" />
+    <Text Include="tests\res40002.txt" />
+    <Text Include="tests\rnsbg.txt" />
+    <Text Include="tests\rrdtr.txt" />
+    <Text Include="tests\rrxtr.txt" />
+    <Text Include="tests\srdt.txt" />
+    <Text Include="tests\stfle.txt" />
+    <Text Include="tests\stidp.txt" />
+    <Text Include="tests\stsi.txt" />
+    <Text Include="tests\sus40002.txt" />
+    <Text Include="tests\tape.240k-2.txt" />
+    <Text Include="tests\tape.240k.txt" />
+    <Text Include="tests\tape.2m.txt" />
+    <Text Include="tests\tape.32k.txt" />
+    <Text Include="tests\tapepos.txt" />
+    <Text Include="tests\tbedr.txt" />
+    <Text Include="tests\tdcdt.txt" />
+    <Text Include="tests\tdgdt.txt" />
+    <Text Include="tests\thder.txt" />
+    <Text Include="tests\trace.txt" />
+    <Text Include="tests\trte.txt" />
+    <Text Include="util\CMPSC.txt" />
+    <Text Include="util\TMOUNT.txt" />
+    <Text Include="_TODO.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Library Include="crypto\lib\crypto32.lib" />
+    <Library Include="crypto\lib\crypto32d.lib" />
+    <Library Include="crypto\lib\crypto64.lib" />
+    <Library Include="crypto\lib\crypto64d.lib" />
+    <Library Include="decNumber\lib\decNumber32.lib" />
+    <Library Include="decNumber\lib\decNumber32d.lib" />
+    <Library Include="decNumber\lib\decNumber64.lib" />
+    <Library Include="decNumber\lib\decNumber64d.lib" />
+    <Library Include="SoftFloat\lib\SoftFloat32.lib" />
+    <Library Include="SoftFloat\lib\SoftFloat32d.lib" />
+    <Library Include="SoftFloat\lib\SoftFloat64.lib" />
+    <Library Include="SoftFloat\lib\SoftFloat64d.lib" />
+    <Library Include="telnet\lib\telnet32.lib" />
+    <Library Include="telnet\lib\telnet32d.lib" />
+    <Library Include="telnet\lib\telnet64.lib" />
+    <Library Include="telnet\lib\telnet64d.lib" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="hercdasd.ico" />
+    <Image Include="hercmisc.ico" />
+    <Image Include="herctape.ico" />
+    <Image Include="hercules.ico" />
+    <Image Include="html\images\back.gif" />
+    <Image Include="html\images\bkued.gif" />
+    <Image Include="html\images\blueu.gif" />
+    <Image Include="html\images\dial1.gif" />
+    <Image Include="html\images\dial2.gif" />
+    <Image Include="html\images\dial3.gif" />
+    <Image Include="html\images\dial4.gif" />
+    <Image Include="html\images\favicon.ico" />
+    <Image Include="html\images\greend.gif" />
+    <Image Include="html\images\greenu.gif" />
+    <Image Include="html\images\hercpic-rblk-256.gif" />
+    <Image Include="html\images\hercpic-rblk-80.gif" />
+    <Image Include="html\images\interruptd.gif" />
+    <Image Include="html\images\interruptu.gif" />
+    <Image Include="html\images\loadd.gif" />
+    <Image Include="html\images\loadoffu.gif" />
+    <Image Include="html\images\loadonu.gif" />
+    <Image Include="html\images\loadu.gif" />
+    <Image Include="html\images\manoffu.gif" />
+    <Image Include="html\images\manonu.gif" />
+    <Image Include="html\images\note.gif" />
+    <Image Include="html\images\osi-certified-60x50.jpg" />
+    <Image Include="html\images\poweroffd.gif" />
+    <Image Include="html\images\poweroffu.gif" />
+    <Image Include="html\images\poweronoffd.gif" />
+    <Image Include="html\images\poweronoffu.gif" />
+    <Image Include="html\images\poweronond.gif" />
+    <Image Include="html\images\powerononu.gif" />
+    <Image Include="html\images\redd.gif" />
+    <Image Include="html\images\redu.gif" />
+    <Image Include="html\images\restartd.gif" />
+    <Image Include="html\images\restartu.gif" />
+    <Image Include="html\images\startd.gif" />
+    <Image Include="html\images\startu.gif" />
+    <Image Include="html\images\stopd.gif" />
+    <Image Include="html\images\stopu.gif" />
+    <Image Include="html\images\stored.gif" />
+    <Image Include="html\images\storeu.gif" />
+    <Image Include="html\images\sysoffu.gif" />
+    <Image Include="html\images\sysonu.gif" />
+    <Image Include="html\images\telnetputtyconndata.png" />
+    <Image Include="html\images\telnetputtysession.png" />
+    <Image Include="html\images\telnetputtyterminal.png" />
+    <Image Include="html\images\telnetwin.png" />
+    <Image Include="html\images\telnetwin10.png" />
+    <Image Include="html\images\telnetwinntconnect.png" />
+    <Image Include="html\images\telnetwinnttermpref.png" />
+    <Image Include="html\images\translucentoffd.gif" />
+    <Image Include="html\images\translucentoffu.gif" />
+    <Image Include="html\images\translucentond.gif" />
+    <Image Include="html\images\translucentonu.gif" />
+    <Image Include="html\images\waitoffu.gif" />
+    <Image Include="html\images\waitonu.gif" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="hercdasd.rc" />
+    <ResourceCompile Include="hercmisc.rc" />
+    <ResourceCompile Include="hercprod.rc" />
+    <ResourceCompile Include="herctape.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc.makefile.includes/VSVERS.msvc
+++ b/msvc.makefile.includes/VSVERS.msvc
@@ -23,6 +23,7 @@
 #
 #-------------------------------------------------------------------
 
+vers_vs2019=16
 vers_vs2017=15
 vers_vs2015=14
 vers_vs2013=12
@@ -31,7 +32,10 @@ vers_vs2010=10
 vers_vs2008=9
 vers_vs2005=8
 
-!IFDEF VS150COMNTOOLS
+!IFDEF VS160COMNTOOLS
+!MESSAGE Makefile presuming VS2019 (VS16 = _MSC_VER 1920)
+vsversion=$(vers_vs2019)
+!ELSEIFDEF VS150COMNTOOLS
 !MESSAGE Makefile presuming VS2017 (VS15 = _MSC_VER 1910 - 1912)
 vsversion=$(vers_vs2017)
 !ELSEIFDEF VS140COMNTOOLS

--- a/vstools.cmd
+++ b/vstools.cmd
@@ -62,9 +62,9 @@
   echo              vstarget        The requested target architecture:
   echo                              "x86" if '32', "amd64" if '64'.
   echo.
-  echo              vs2017..vs2005  The Visual Studio version numbers
+  echo              vs2019..vs2005  The Visual Studio version numbers
   echo                              for each supported version of it
-  echo                              (vs2017=150, vs2008=90, etc)
+  echo                              (vs2019=160, vs2017=150, etc)
   echo.
   echo     EXIT STATUS
   echo.
@@ -98,9 +98,10 @@
   set "vs2013=120"
   set "vs2015=140"
   set "vs2017=150"
+  set "vs2019=160"
 
-  set "VSNAMES=vs2017 vs2015 vs2013 vs2012 vs2010 vs2008 vs2005"
-
+  set "VSNAMES=vs2019 vs2017 vs2015 vs2013 vs2012 vs2010 vs2008 vs2005"
+  
   set "vsname="
   set "vsver="
   set "vshost="

--- a/vsvers.h
+++ b/vsvers.h
@@ -18,6 +18,7 @@
 /*    Don't forget to update the 'makefile.bat' file too!            */
 /*-------------------------------------------------------------------*/
 
+#define VS2019      1920                /* Visual Studio 2019 */
 #define VS2017_5    1912                /* Visual Studio 2017 */
 #define VS2017_4    1911                /* Visual Studio 2017 */
 #define VS2017_3    1911                /* Visual Studio 2017 */
@@ -33,6 +34,7 @@
 #define VS2003      1310                /* Visual Studio 2003 */
 #define VS2002      1300                /* Visual Studio 2002 */
 
+#define MSVC16      1920                /* Visual Studio 2019 */
 #define MSVC15_5    1912                /* Visual Studio 2017 */
 #define MSVC15_4    1911                /* Visual Studio 2017 */
 #define MSVC15_3    1911                /* Visual Studio 2017 */


### PR DESCRIPTION
The [build instructions](http://www.softdevlabs.com/hercules-vs2015-build.html) for SDL Hyperion document Visual Studio Community 2017, which is no longer easily (that I could find) available for download from Microsoft.  Visual Studio Community 2019 however is readily available.

These updates allow building the code using Visual Studio 2019.

First time using GitHub, so hoping what I've done is correct.