### PR TITLE
Do not install build system artifacts

### DIFF
--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -53,7 +53,6 @@ dist_pkgdata_DATA =   \
     hercules.css      \
     hercules.html     \
     index.html        \
-    Makefile.am       \
     rexx.html         \
     shared.html       \
     tasks.html        \
@@ -124,4 +123,7 @@ images_sources =                        \
 images_pkgdatadir = $(pkgdatadir)/images
 
 dist_images_pkgdata_DATA = $(images_sources)
+
+EXTRA_DIST =        \
+    Makefile.am
 

--- a/html/Makefile.in
+++ b/html/Makefile.in
@@ -337,7 +337,6 @@ dist_pkgdata_DATA = \
     hercules.css      \
     hercules.html     \
     index.html        \
-    Makefile.am       \
     rexx.html         \
     shared.html       \
     tasks.html        \
@@ -405,6 +404,9 @@ images_sources = \
 
 images_pkgdatadir = $(pkgdatadir)/images
 dist_images_pkgdata_DATA = $(images_sources)
+EXTRA_DIST = \
+    Makefile.am
+
 all: all-am
 
 .SUFFIXES:

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,7 +2,8 @@ man_MANS =      \
     cckd.4      \
     cckddiag.1  \
     dasdseq.1   \
-    Makefile.am \
     vmfplc2.1
 
-EXTRA_DIST = $(man_MANS)
+EXTRA_DIST =    \
+    $(man_MANS) \
+    Makefile.am

--- a/man/Makefile.in
+++ b/man/Makefile.in
@@ -147,10 +147,8 @@ am__uninstall_files_from_dir = { \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
 man1dir = $(mandir)/man1
-am__installdirs = "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man4dir)" \
-	"$(DESTDIR)$(manadir)"
+am__installdirs = "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man4dir)"
 man4dir = $(mandir)/man4
-manadir = $(mandir)/mana
 NROFF = nroff
 MANS = $(man_MANS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
@@ -287,10 +285,12 @@ man_MANS = \
     cckd.4      \
     cckddiag.1  \
     dasdseq.1   \
-    Makefile.am \
     vmfplc2.1
 
-EXTRA_DIST = $(man_MANS)
+EXTRA_DIST = \
+    $(man_MANS) \
+    Makefile.am
+
 all: all-am
 
 .SUFFIXES:
@@ -415,49 +415,6 @@ uninstall-man4:
 	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^4][0-9a-z]*$$,4,;x' \
 	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
 	dir='$(DESTDIR)$(man4dir)'; $(am__uninstall_files_from_dir)
-install-mana: $(man_MANS)
-	@$(NORMAL_INSTALL)
-	@list1=''; \
-	list2='$(man_MANS)'; \
-	test -n "$(manadir)" \
-	  && test -n "`echo $$list1$$list2`" \
-	  || exit 0; \
-	echo " $(MKDIR_P) '$(DESTDIR)$(manadir)'"; \
-	$(MKDIR_P) "$(DESTDIR)$(manadir)" || exit 1; \
-	{ for i in $$list1; do echo "$$i"; done;  \
-	if test -n "$$list2"; then \
-	  for i in $$list2; do echo "$$i"; done \
-	    | sed -n '/\.a[a-z]*$$/p'; \
-	fi; \
-	} | while read p; do \
-	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
-	  echo "$$d$$p"; echo "$$p"; \
-	done | \
-	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^a][0-9a-z]*$$,a,;x' \
-	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
-	sed 'N;N;s,\n, ,g' | { \
-	list=; while read file base inst; do \
-	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
-	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(manadir)/$$inst'"; \
-	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(manadir)/$$inst" || exit $$?; \
-	  fi; \
-	done; \
-	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
-	while read files; do \
-	  test -z "$$files" || { \
-	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(manadir)'"; \
-	    $(INSTALL_DATA) $$files "$(DESTDIR)$(manadir)" || exit $$?; }; \
-	done; }
-
-uninstall-mana:
-	@$(NORMAL_UNINSTALL)
-	@list=''; test -n "$(manadir)" || exit 0; \
-	files=`{ for i in $$list; do echo "$$i"; done; \
-	l2='$(man_MANS)'; for i in $$l2; do echo "$$i"; done | \
-	  sed -n '/\.a[a-z]*$$/p'; \
-	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^a][0-9a-z]*$$,a,;x' \
-	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
-	dir='$(DESTDIR)$(manadir)'; $(am__uninstall_files_from_dir)
 tags TAGS:
 
 ctags CTAGS:
@@ -502,7 +459,7 @@ check-am: all-am
 check: check-am
 all-am: Makefile $(MANS)
 installdirs:
-	for dir in "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man4dir)" "$(DESTDIR)$(manadir)"; do \
+	for dir in "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man4dir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -571,7 +528,7 @@ install-info: install-info-am
 
 install-info-am:
 
-install-man: install-man1 install-man4 install-mana
+install-man: install-man1 install-man4
 
 install-pdf: install-pdf-am
 
@@ -601,7 +558,7 @@ ps-am:
 
 uninstall-am: uninstall-man
 
-uninstall-man: uninstall-man1 uninstall-man4 uninstall-mana
+uninstall-man: uninstall-man1 uninstall-man4
 
 .MAKE: install-am install-strip
 
@@ -611,13 +568,12 @@ uninstall-man: uninstall-man1 uninstall-man4 uninstall-mana
 	install install-am install-data install-data-am install-dvi \
 	install-dvi-am install-exec install-exec-am install-html \
 	install-html-am install-info install-info-am install-man \
-	install-man1 install-man4 install-mana install-pdf \
-	install-pdf-am install-ps install-ps-am install-strip \
-	installcheck installcheck-am installdirs maintainer-clean \
+	install-man1 install-man4 install-pdf install-pdf-am \
+	install-ps install-ps-am install-strip installcheck \
+	installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-generic \
 	mostlyclean-libtool pdf pdf-am ps ps-am tags-am uninstall \
-	uninstall-am uninstall-man uninstall-man1 uninstall-man4 \
-	uninstall-mana
+	uninstall-am uninstall-man uninstall-man1 uninstall-man4
 
 .PRECIOUS: Makefile
 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,6 +1,5 @@
 
 bin_SCRIPTS =       \
-    bldlvlck        \
     dasdlist        \
     voldsext.cmd
 
@@ -18,6 +17,7 @@ dist_pkgdata_DATA = \
 
 
 EXTRA_DIST =        \
+    bldlvlck        \
     configure.ac    \
     dasdlist.bat    \
     Makefile.am

--- a/util/Makefile.in
+++ b/util/Makefile.in
@@ -283,7 +283,6 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 bin_SCRIPTS = \
-    bldlvlck        \
     dasdlist        \
     voldsext.cmd
 
@@ -299,6 +298,7 @@ dist_pkgdata_DATA = \
     zzsacard.bin
 
 EXTRA_DIST = \
+    bldlvlck        \
     configure.ac    \
     dasdlist.bat    \
     Makefile.am


### PR DESCRIPTION
Avoid installing `bldlvlck` and the `Makefile.am` when doing `make install`, as they're only needed at build time. Also regenerate autotools in a separate commit for convenience.