### PR TITLE
Update thread creation to save thread name, fix issue #249

### DIFF
--- a/hthreads.c
+++ b/hthreads.c
@@ -812,7 +812,7 @@ DLL_EXPORT int  hthread_create_thread( TID* ptid, ATTR* pat,
     arg2 = malloc( 3 * sizeof( void* ));
     *(arg2+0) = (void*) pfn;
     *(arg2+1) = (void*) arg;
-    *(arg2+2) = (void*) name;
+    *(arg2+2) = (void*) strdup(name);
     rc = hthread_create( ptid, pat, hthread_func, arg2 );
     PTTRACE( "create", (void*)*ptid, NULL, location, rc );
     return rc;


### PR DESCRIPTION
Fix to save copy of thread name on heap so that process thread listing is correct in LINUX "ps -T". 
Note that subsequent uses of name do check for null pointer so use of strdup() is safe in this case.