### PR TITLE
Fix issue where thread names are incorrectly set

### DIFF
--- a/hthreads.c
+++ b/hthreads.c
@@ -794,7 +794,10 @@ static void* hthread_func( void* arg2 )
     void*         rc;
     free( arg2 );
     if (name)
+    {
         SET_THREAD_NAME_ID( tid, name );
+        free(name);
+    }
     rc = pfn( arg );
     hthread_list_abandoned_locks( tid, NULL );
     return rc;
@@ -812,7 +815,7 @@ DLL_EXPORT int  hthread_create_thread( TID* ptid, ATTR* pat,
     arg2 = malloc( 3 * sizeof( void* ));
     *(arg2+0) = (void*) pfn;
     *(arg2+1) = (void*) arg;
-    *(arg2+2) = (void*) name;
+    *(arg2+2) = (void*) strdup(name);
     rc = hthread_create( ptid, pat, hthread_func, arg2 );
     PTTRACE( "create", (void*)*ptid, NULL, location, rc );
     return rc;


### PR DESCRIPTION
Create copy of thread name on heap to prevent pointer reference on callers stack being used. 
Free heap area for name after use.