### PR TITLE
Correct spelling in msgs

### DIFF
--- a/archlvl.c
+++ b/archlvl.c
@@ -347,7 +347,7 @@ int archlvl_cmd( int argc, char* argv[], char* cmdline )
             bool increased = (new_mainsize > old_mainsize);
             fmt_memsize_KB( sysblk.mainsize >> SHIFT_KIBIBYTE, memsize, sizeof( memsize ));
 
-            // "MAINSIZE %screased to %s architectural %simim"
+            // "MAINSIZE %screased to %s architectural %simum"
             WRMSG( HHC17006, "W", increased ? "in" : "de", memsize,
                 increased ? "min" : "max" );
         }

--- a/msgenu.h
+++ b/msgenu.h
@@ -2434,7 +2434,7 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp );
 #define HHC17003 "%-8s storage is %s (%ssize); storage is %slocked"
 #define HHC17004 "%-6s: CPUID  = %16.16"PRIX64
 #define HHC17005 "%-6s: CPC SI = %4.4X.%s.%s.%s.%s"
-#define HHC17006 "MAINSIZE %screased to %s architectural %simim"
+#define HHC17006 "MAINSIZE %screased to %s architectural %simum"
 #define HHC17007 "NumCPU = %2.2d, NumVEC = %2.2d, ReservedCPU = %2.2d, MaxCPU = %2.2d"
 #define HHC17008 "Avgproc  %2.2d %3.3d%%; MIPS[%4d.%2.2d]; SIOS[%6d]%s"
 #define HHC17009 "PROC %s%2.2X %c %3.3d%%; MIPS[%4d.%2.2d]; SIOS[%6d]%s"

--- a/tests/mainsize.tst
+++ b/tests/mainsize.tst
@@ -184,7 +184,7 @@ archlvl z/Arch
   mainsize 3g
 
   archlvl s/370
-  *Info 1 HHC17006W MAINSIZE decreased to 2G architectural maximim
+  *Info 1 HHC17006W MAINSIZE decreased to 2G architectural maximum
 
 *Fi
 
@@ -196,7 +196,7 @@ mainsize 64k
 * Test 25
 
 archlvl z/Arch
-*Info 2 HHC17006W MAINSIZE increased to 1M architectural minimim
+*Info 2 HHC17006W MAINSIZE increased to 1M architectural minimum
 
 *Done nowait
 


### PR DESCRIPTION
Correct spelling of "minimum" and "maximum" in HHC17006W messages, and the tests that look at those messages.