### PR TITLE
Split out gcc version check for 32-bit i686 vs others

### DIFF
--- a/util/bldlvlck
+++ b/util/bldlvlck
@@ -31,7 +31,7 @@ my @req = qw(
      cmake       3.2    0  https://cmake.org
      flex        2.5    0  http://www.gnu.org/directory/flex.html
      gawk        3.0    0  http://www.gnu.org/directory/gawk.html
-     gcc         4.6.2  0  http://www.gnu.org/directory/gcc.html
+     gcc         4.6.2  1  http://www.gnu.org/directory/gcc.html
      grep        1      0  http://www.gnu.org/directory/grep.html
      ld          2.22   0  http://www.gnu.org/directory/binutils.html
      m4          1.4.6  0  http://www.gnu.org/directory/GNU/gnum4.html
@@ -40,10 +40,15 @@ my @req = qw(
      sed         3.02   0  http://www.gnu.org/directory/sed.html
 );
 
+my $gcc_i686_required = "6.3.0";
+
 my $msg;
 my $instversion;
 
 sayintro();
+
+my $machine = `uname -m`;
+print "Machine architecture is $machine\n";
 
 for (my $i = 0; $i < @req; $i += 4) {
   my $facility = $req[$i];
@@ -93,6 +98,7 @@ sub weird {
     }
     return;
   }
+
   if ($facility eq 'libtool') {
     if (present($facility, $url)) {
       my @resp = `libtoolize --version`;
@@ -105,6 +111,7 @@ sub weird {
     }
     return;
   }
+
   if ($facility eq 'm4') {      # m4 --version: GNU m4 1.4o
     if (present($facility, $url)) {
       my $resp = `m4 --version`;
@@ -123,6 +130,26 @@ sub weird {
     }
     return;
   }
+
+  if ($facility eq 'gcc') {
+    if (present($facility, $url)) {
+      my @resp = `$facility --version`;
+      chomp $resp[0];
+      $instversion = getvers($resp[0]);
+
+      if ($machine =~ /i686/) {
+          $msg = ckvers($gcc_i686_required, $instversion);
+          print "$msg\t$facility (32-bit) requires $gcc_i686_required, found $instversion\n";
+      } else {
+          $msg = ckvers($level, $instversion);
+          print "$msg\t$facility requires $level, found $instversion\n";
+      }
+      print "\tURL: $url\n" if $msg eq 'UPGRADE';
+    }
+
+    return;
+  }
+
   print "ERROR $facility flagged as special, not found\n";
 }
 


### PR DESCRIPTION
Suggest a different gcc version (6.3.0) as the minimum requirement for 32-bit i686 systems.
This is required to get working atomics and pass the CBUC test.

64-bit system work correctly with the existing older minimum version, which is unchanged.
