### PR TITLE
Make the call to recv on the telnet connection non-blocking.

### DIFF
--- a/console.c
+++ b/console.c
@@ -2783,8 +2783,14 @@ BYTE    buf[BUFLEN_1052];               /* Receive buffer            */
         // "%s COMM: recv() failed: %s"
         CONERROR( HHC90507, "D", dev->tn->clientid, strerror( HSO_errno ));
 
-        dev->sense[0] = SENSE_EC;
-        return (CSW_ATTN | CSW_UC);
+        if (HSO_EAGAIN == HSO_errno)
+            // non blocking call and no data
+            return 0;
+        else
+        {
+            dev->sense[0] = SENSE_EC;
+            return (CSW_ATTN | CSW_UC);
+        }
     }
 
     /* If zero bytes were received then client has closed connection */

--- a/console.c
+++ b/console.c
@@ -3751,17 +3751,18 @@ int prev_rlen3270;
                 consio();
 
                 /* Receive console input data from the client */
+
+                /* Make the first call to recv  elow non-blocking
+                   in case pselect lied to us and there isn't any
+                   data available.  If we do multiple recv's then
+                   the subsequent ones are blocking 
+                   
+                   See the linux man page for select(2) for 
+                   more info. */
+                socket_set_blocking_mode( dev->fd, 0 );
                 if ((dev->devtype == 0x3270) ||
                     (dev->devtype == 0x3287))
                 {
-                    /* Make the first call to recv  elow non-blocking
-                       in case pselect lied to us and there isn't any
-                       data available.  If we do multiple recv's then
-                       the subsequent ones are blocking 
-                       
-                       See the linux man page for select(2) for 
-                       more info. */
-                    socket_set_blocking_mode( dev->fd, 0 );
                     do
                         {
                             prev_rlen3270 = dev->rlen3270;


### PR DESCRIPTION
The device lock is held when this call is made and if it blocks
things go down hill in a hurry.  According to the Linux select(2)
man page a call to recv may block even a previous call to select
says it shouldn't.  This has also been seen on MacOSX.

This fixes issue 377