### PR TITLE
Corrections to autoconf for BSD 12 shared libraries

### DIFF
--- a/autoconf/config.rpath
+++ b/autoconf/config.rpath
@@ -236,7 +236,7 @@ else
     darwin* | rhapsody*)
       hardcode_direct=yes
       ;;
-    freebsd1*)
+    freebsd1 | freebsd1.*)
       ld_shlibs=no
       ;;
     freebsd2.2*)
@@ -389,8 +389,6 @@ case "$host_os" in
     ;;
   darwin* | rhapsody*)
     shlibext=dylib
-    ;;
-  freebsd1*)
     ;;
   freebsd*)
     shlibext=so

--- a/autoconf/libtool.m4
+++ b/autoconf/libtool.m4
@@ -1307,10 +1307,6 @@ dgux*)
   shlibpath_var=LD_LIBRARY_PATH
   ;;
 
-freebsd1*)
-  dynamic_linker=no
-  ;;
-
 kfreebsd*-gnu)
   version_type=linux
   need_lib_prefix=no
@@ -1323,7 +1319,9 @@ kfreebsd*-gnu)
   dynamic_linker='GNU ld.so'
   ;;
 
-freebsd*)
+# FreeBSD before 4.0 may have supported a.out format.
+# Test for it, and if the objformat migration tool does not exist, assume a.out.
+freebsd2 | freebsd2.* | freebsd3 | freebsd3.* )
   objformat=`test -x /usr/bin/objformat && /usr/bin/objformat || echo aout`
   version_type=freebsd-$objformat
   case $version_type in
@@ -1351,6 +1349,16 @@ freebsd*)
     hardcode_into_libs=yes
     ;;
   esac
+  ;;
+
+# FreeBSD 4 and higher always support, and only support, ELF
+freebsd*)
+  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${release}${shared_ext} $libname${shared_ext}'
+  need_version=no
+  need_lib_prefix=no
+  shlibpath_var=LD_LIBRARY_PATH
+  shlibpath_overrides_runpath=no
+  hardcode_into_libs=yes
   ;;
 
 gnu*)
@@ -5430,10 +5438,6 @@ EOF
       _LT_AC_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
       _LT_AC_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
       _LT_AC_TAGVAR(hardcode_shlibpath_var, $1)=no
-      ;;
-
-    freebsd1*)
-      _LT_AC_TAGVAR(ld_shlibs, $1)=no
       ;;
 
     # FreeBSD 2.2.[012] allows us to include c++rt0.o to get C++ constructor

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,14 @@ AM_MAINTAINER_MODE()
 AC_CANONICAL_HOST()           # (sets $host_cpu, $host_vendor, and $host_os)
 AC_CANONICAL_TARGET()         # (sets $target_cpu, $target_vendor, and $target_os)
 
+# FORTRAN detection scanning can goof up our shared libraries.
+# So we diable checking for it.  And C++, too, while we're at it.
+#
+# Idea from https://stackoverflow.com/questions/4292683
+#
+m4_defun([_LT_AC_LANG_CXX_CONFIG], [:])
+m4_defun([_LT_AC_LANG_F77_CONFIG], [:])
+
 ###############################################################################
 #   Programs section...
 ###############################################################################
@@ -364,6 +372,14 @@ AC_LIBTOOL_WIN32_DLL()                  # (we need Win32 support in libtool)
 # -----------------------------------------------------------------------------
 
 case $host_os in
+    freebsd1 | freebsd1.* | freebsd2 | freebsd2.* | freebsd3 | freebsd3.*)
+      lt_cv_deplibs_check_method="match_pattern /lib[^/]+(\\.so|_pic\\.a|\\.a)\$"
+      ;;
+
+    freebsd*)
+      lt_cv_deplibs_check_method="pass_all"
+      ;;
+
     netbsd*)
       #lt_cv_deplibs_check_method="match_pattern /lib[^/]+(\\.so|_pic\\.a|\\.a)\$"
       lt_cv_deplibs_check_method="pass_all"


### PR DESCRIPTION
The autoconf/automake, etc. included with Hercules are 15 to 20 years out of date and were never set up to handle newer FreeBSD properly.  As a result shared libraries and linking are not handled.  This change addresses that.
