### PR TITLE
Bump minimum gcc version to 5 for proper "inline" behavior

### DIFF
--- a/util/bldlvlck
+++ b/util/bldlvlck
@@ -31,7 +31,7 @@ my @req = qw(
      cmake       3.2    0  https://cmake.org
      flex        2.5    0  http://www.gnu.org/directory/flex.html
      gawk        3.0    0  http://www.gnu.org/directory/gawk.html
-     gcc         4.6.2  1  http://www.gnu.org/directory/gcc.html
+     gcc         5.0.0  1  http://www.gnu.org/directory/gcc.html
      grep        1      0  http://www.gnu.org/directory/grep.html
      ld          2.22   0  http://www.gnu.org/directory/binutils.html
      m4          1.4.6  0  http://www.gnu.org/directory/GNU/gnum4.html


### PR DESCRIPTION
Recent changes to improve performance of inlined functions require gcc 5 or greater (to get the desired behavior by default).