### PR TITLE
Fix build errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -410,6 +410,7 @@ libhercu_la_SOURCES = \
   hthreads.c          \
   logger.c            \
   logmsg.c            \
+  machdep.c           \
   memrchr.c           \
   parser.c            \
   pttrace.c           \

--- a/Makefile.in
+++ b/Makefile.in
@@ -346,16 +346,16 @@ libherct_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 libhercu_la_DEPENDENCIES = $(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
 	libhercs.la
 am__libhercu_la_SOURCES_DIST = codepage.c hdl.c hexdumpe.c hostinfo.c \
-	hscutl.c hsocket.c hthreads.c logger.c logmsg.c memrchr.c \
-	parser.c pttrace.c version.c fthreads.c ltdl.c
+	hscutl.c hsocket.c hthreads.c logger.c logmsg.c machdep.c \
+	memrchr.c parser.c pttrace.c version.c fthreads.c ltdl.c
 am__objects_2 = fthreads.lo
 @BUILD_FTHREADS_TRUE@am__objects_3 = $(am__objects_2)
 @BUILD_APPLE_M1_FALSE@am__objects_4 = ltdl.lo
 @BUILD_APPLE_M1_FALSE@am__objects_5 = $(am__objects_4)
 am_libhercu_la_OBJECTS = codepage.lo hdl.lo hexdumpe.lo hostinfo.lo \
 	hscutl.lo hsocket.lo hthreads.lo logger.lo logmsg.lo \
-	memrchr.lo parser.lo pttrace.lo version.lo $(am__objects_3) \
-	$(am__objects_5)
+	machdep.lo memrchr.lo parser.lo pttrace.lo version.lo \
+	$(am__objects_3) $(am__objects_5)
 libhercu_la_OBJECTS = $(am_libhercu_la_OBJECTS)
 libhercu_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
@@ -1332,6 +1332,7 @@ libhercu_la_SOURCES = \
   hthreads.c          \
   logger.c            \
   logmsg.c            \
+  machdep.c           \
   memrchr.c           \
   parser.c            \
   pttrace.c           \

--- a/skey.c
+++ b/skey.c
@@ -124,4 +124,11 @@ extern inline BYTE ARCH_DEP(  _get_dev_storage_key  )( DEVBLK* dev, U64 abs,    
   extern inline bool bypass_skey_update( REGS* regs, BYTE m3, BYTE oldkey, BYTE r1key );
 #endif
 
+  extern inline BYTE* _get_storekey_ptr( U64 abs, BYTE K );
+  extern inline BYTE* _get_dev_storekey_ptr( DEVBLK* dev, U64 abs, BYTE K );
+  extern inline BYTE* _get_storekey1_ptr( U64 abs );
+  extern inline BYTE* _get_storekey2_ptr( U64 abs );
+  extern inline BYTE* _get_dev_storekey1_ptr( DEVBLK* dev, U64 abs );
+  extern inline BYTE* _get_dev_storekey2_ptr( DEVBLK* dev, U64 abs );
+  
 #endif /*!defined( _GEN_ARCH )*/

--- a/skey.c
+++ b/skey.c
@@ -11,6 +11,7 @@
 #define _HENGINE_DLL_
 
 #include "hercules.h"
+#include "inline.h"
 
 /*-------------------------------------------------------------------*/
 /*   ARCH_DEP section: compiled multiple times, once for each arch.  */


### PR DESCRIPTION
The current master branch doesn't build using GCC 8.4 on MacOS Mojave.  These changes make it build and it seems to work ok.  These may not be the best fixes but they seem plausible and will serve to document the build errors and one way to fix them.