### PR TITLE
Ignore hercules-helper's build directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .DS_Store
 .deps/
 .libs/
+build/
 Makefile
 autogen.log
 config.log


### PR DESCRIPTION
For those of us using Bill Lewis's excellent `hercules-helper` script to build and install, this will tell git to ignore the build directory it uses inside the Hyperion tree.