### PR TITLE
Fix gcc compile error on Linux in the LCS SNA support code.

### DIFF
--- a/ctcadpt.h
+++ b/ctcadpt.h
@@ -138,7 +138,6 @@ extern void     CTCI_Write( DEVBLK* pDEVBLK,   U32   sCount,
                             U32*    pResidual );
 
 extern int      LCS_Init( DEVBLK* pDEVBLK, int argc, char *argv[] );
-extern void     LCS_Assist( PLCSPORT pLCSPORT );
 extern int      LCS_Close( DEVBLK* pDEVBLK );
 extern void     LCS_Query( DEVBLK* pDEVBLK, char** ppszClass,
                            int     iBufLen, char*  pBuffer );
@@ -148,13 +147,6 @@ extern void     LCS_ExecuteCCW( DEVBLK* pDEVBLK, BYTE  bCode,
                                 int     iCCWSeq, BYTE* pIOBuf,
                                 BYTE*   pMore,   BYTE* pUnitStat,
                                 U32*    pResidual );
-
-extern void     LCS_Read( DEVBLK* pDEVBLK,   U32   sCount,
-                          BYTE*   pIOBuf,    BYTE* UnitStat,
-                          U32*    pResidual, BYTE* pMore );
-extern void     LCS_Write( DEVBLK* pDEVBLK,   U32   sCount,
-                           BYTE*   pIOBuf,    BYTE* UnitStat,
-                           U32*    pResidual );
 
 extern void     packet_trace( BYTE *addr, int len, BYTE dir );
 


### PR DESCRIPTION
The LCS support code as committed refuses to build with gcc on Linux because three functions are defined as static in `ctc-lcs.c` and not as static in `ctcadapt.h`.  Since those functions are not used outside of `ctc-lcs.c`, there's no need to define them in `ctcadapt.h`, so the easiest way to fix the error is simply to remove the definitions from the header file.