### PR TITLE
Do not install voldsext.cmd

### DIFF
--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,7 +1,6 @@
 
 bin_SCRIPTS =       \
-    dasdlist        \
-    voldsext.cmd
+    dasdlist
 
 
 dist_pkgdata_DATA = \
@@ -21,5 +20,6 @@ EXTRA_DIST =        \
     bldlvlck        \
     configure.ac    \
     dasdlist.bat    \
+    voldsext.cmd    \
     Makefile.am
 


### PR DESCRIPTION
voldsext.cmd is only useful on Windows. Similarly to others scripts under util/, don't install it as a binary but just include it in the distribution.