### PR TITLE
Fix UB when calling ctype functions.

### DIFF
--- a/cckddiag.c
+++ b/cckddiag.c
@@ -487,7 +487,7 @@ static off_t offtify(char *s)
     {
         s = s + 2;
 
-        for (v = 0; isxdigit(*s); ++s)
+        for (v = 0; isxdigit((unsigned char)*s); ++s)
             v = (v << 4) + xv[ strchr( xd, *s ) - xd ];
 
         if (debug)

--- a/cckddiag64.c
+++ b/cckddiag64.c
@@ -476,7 +476,7 @@ static U64 offtify(char *s)
     {
         s = s + 2;
 
-        for (v = 0; isxdigit(*s); ++s)
+        for (v = 0; isxdigit((unsigned char)*s); ++s)
             v = (v << 4) + xv[ strchr( xd, *s ) - xd ];
 
         if (debug)

--- a/cgibin.c
+++ b/cgibin.c
@@ -1271,7 +1271,7 @@ void cgibin_cmd_cmd(WEBBLK *webblk, char *command)
 {
     char * response;
 
-    while (isspace(*command))
+    while (isspace((unsigned char)*command))
         command++;
 
     if (*command == 0)

--- a/chsc.c
+++ b/chsc.c
@@ -742,7 +742,7 @@ BYTE dumpbuf[32*1024] = {0};
         MSGBUF( hex, "%2.2X", *p );
         STRLCAT( hexbuf, hex );
         c = guest_to_host(*p);
-        if (!isprint(c) || iscntrl(c)) c = '.';
+        if (!isprint((unsigned char)c) || iscntrl((unsigned char)c)) c = '.';
         charbuf[disp & 15] = c;
     }
 

--- a/ckddasd.c
+++ b/ckddasd.c
@@ -3857,7 +3857,7 @@ BYTE            trk_ovfl;               /* == 1 if track ovfl write  */
            the key, which will usually be a dataset name or member
            name and can provide useful debugging information */
         if ((*unitstat & CSW_SM) && dev->ckdkeytrace
-            && isprint(guest_to_host(iobuf[0])))
+            && isprint((unsigned char)guest_to_host(iobuf[0])))
         {
             BYTE module[45];
             size_t kl = MIN( (size_t)num, sizeof( module ) - 1 );

--- a/cmdtab.c
+++ b/cmdtab.c
@@ -761,7 +761,7 @@ DLL_EXPORT void* the_real_panel_command( char* cmdline )
     */
     hercecho = 1;   // (default)
 
-    while (*pCmdLine && isspace( *pCmdLine ))
+    while (*pCmdLine && isspace( (unsigned char)*pCmdLine ))
         pCmdLine++;
 
     i = 0;
@@ -780,7 +780,7 @@ DLL_EXPORT void* the_real_panel_command( char* cmdline )
                 pCmdLine++;         /* (skip past the '-' ... */
                                     /* ... and remove blanks) */
 
-                while (*pCmdLine && isspace( *pCmdLine ))
+                while (*pCmdLine && isspace( (unsigned char)*pCmdLine ))
                     pCmdLine++;     /* (get past blank) */
             }
         }

--- a/codepage.c
+++ b/codepage.c
@@ -1474,7 +1474,7 @@ DLL_EXPORT int update_codepage(int argc, char *argv[], char *cmd )
                     }
                     j += idx_snprintf( j, hbuf, sizeof(hbuf), "%2.2X", c );
                     if ( g_to_h) c = guest_to_host(c);
-                    cbuf[k++] = ( !isprint(c) ? '.' : c );
+                    cbuf[k++] = ( !isprint((unsigned char)c) ? '.' : c );
                 } /* end for(i) */
                 WRMSG( HHC01486, "I", ( ( o >> 4 ) & 0xf ), hbuf, cbuf, ( ( o >> 4 ) & 0xf ) );
             }
@@ -1625,7 +1625,7 @@ DLL_EXPORT BYTE* prt_guest_to_host( const BYTE *psinbuf, BYTE *psoutbuf, const u
     for( count = 0; count < ilength; count++ )
     {
         c = guest_to_host(psinbuf[count]);
-        if ( !isprint(c) )
+        if ( !isprint((unsigned char)c) )
             c = '.';
         psoutbuf[count] = c;
     }
@@ -1645,7 +1645,7 @@ DLL_EXPORT BYTE* prt_host_to_guest( const BYTE *psinbuf, BYTE *psoutbuf, const u
             pad = TRUE;
         if ( !pad )
         {
-            psoutbuf[count] = isprint      (psinbuf[count]) ?
+            psoutbuf[count] = isprint      ((unsigned char)psinbuf[count]) ?
                               host_to_guest(psinbuf[count]) :
                               host_to_guest('.');
         }

--- a/comm3705.c
+++ b/comm3705.c
@@ -309,9 +309,9 @@ packet_trace( BYTE* pAddr, int iLen )
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( isprint( (unsigned char)e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( isprint( (unsigned char)c ) )
                     print_ascii[i] = c;
             }
             else

--- a/commadpt.c
+++ b/commadpt.c
@@ -1042,7 +1042,7 @@ static void commadpt_read_tty(COMMADPT *ca, BYTE * bfr, int len)
             }
             if  (ca->uctrans && c >= 'a' && c <= 'z')
             {
-                c = toupper( c );     /* make uppercase */
+                c = toupper( (unsigned char)c );     /* make uppercase */
             }
             /* now map the character from ASCII into proper S/370 byte format */
             if (ca->term == COMMADPT_TERM_TTY)

--- a/con1052c.c
+++ b/con1052c.c
@@ -311,7 +311,7 @@ static void* con1052_panel_command( char *cmd )
             input = cmd + pfxlen;
 
             for (i=0; i < dev->bufsize && input[i] != '\0'; i++)
-                dev->buf[i] = isprint( input[i] ) ?
+                dev->buf[i] = isprint( (unsigned char)input[i] ) ?
                         host_to_guest( input[i] ) : ' ';
 
             /* Update number of bytes in keyboard buffer */
@@ -395,7 +395,7 @@ BYTE    c;                              /* Print character           */
             if (1
                 && c != 0x0d
                 && c != 0x0a
-                && !isprint(c)
+                && !isprint((unsigned char)c)
             )
                 c = ' ';
             iobuf[len] = c;

--- a/console.c
+++ b/console.c
@@ -941,10 +941,10 @@ static int  loc3270_init_handler( DEVBLK* dev, int argc, char* argv[] )
                 strupper( group, argv[ac] );
 
                 for (i=1, rc=0; i < (int) strlen( group ) && rc == 0; i++)
-                    if (!isalnum( group[i] ))
+                    if (!isalnum( (unsigned char)group[i] ))
                         rc = -1;
 
-                if (rc == 0 && isalpha( group[0] ))
+                if (rc == 0 && isalpha( (unsigned char)group[0] ))
                     STRLCPY( dev->filename, group );
                 else
                 {
@@ -1202,7 +1202,7 @@ static struct sockaddr_in* parse_sockspec( const char* sockspec )
 
     // Convert port to number
 
-    if (isdigit( *port ))
+    if (isdigit( (unsigned char)*port ))
         sin->sin_port = htons( atoi( port ));
     else
     {

--- a/control.c
+++ b/control.c
@@ -7511,7 +7511,7 @@ static BYTE hexebcdic[16] = { 0xF0,0xF1,0xF2,0xF3,0xF4,0xF5,0xF6,0xF7,
         BYTE c, s[17]; int j;
         for (j=0; j < 16; j++) {
             c = guest_to_host( m[j] );
-            s[j] = isprint(c) ? c : '.';
+            s[j] = isprint((unsigned char)c) ? c : '.';
         }
         s[j] = '\0';
         LOGMSG( "+%2.2X %2.2X%2.2X%2.2X%2.2X %2.2X%2.2X%2.2X%2.2X "

--- a/ctc_ctci.c
+++ b/ctc_ctci.c
@@ -1536,7 +1536,7 @@ static int  ParseArgs( DEVBLK* pDEVBLK, PCTCBLK pCTCBLK,
 
             char * s = pCTCBLK->szTUNIfName + strlen(pCTCBLK->szTUNIfName);
 
-            while(isdigit(s[- 1])) s--;
+            while(isdigit((unsigned char)s[- 1])) s--;
             STRLCAT( pCTCBLK->szTUNCharDevName, s );
         }
 #endif

--- a/ctc_ptp.c
+++ b/ctc_ptp.c
@@ -2966,7 +2966,7 @@ int  parse_conf_stmt( DEVBLK* pDEVBLK, PTPBLK* pPTPBLK,
          */
         char* s = pPTPBLK->szTUNIfName + strlen( pPTPBLK->szTUNIfName );
 
-        while (isdigit( s[-1] ))
+        while (isdigit( (unsigned char)s[-1] ))
             s--;
 
         STRLCAT( pPTPBLK->szTUNCharDevName, s );

--- a/dasdtab.c
+++ b/dasdtab.c
@@ -539,7 +539,7 @@ BYTE buf[256];
                             dev->ckdtab->devt, dev->ckdtab->model);
         memcpy( &buf[18], dev->serial, 12 );
         for (i = 4; i < 30; i++)
-            buf[i] = host_to_guest( isalnum( buf[i] ) ? buf[i] : '0' );
+            buf[i] = host_to_guest( isalnum( (unsigned char)buf[i] ) ? buf[i] : '0' );
         store_hw(buf + 30, dev->devnum);        /* Uniquely tag within system */
 
         /* Bytes 32-63: NED 2  Node element descriptor for the string */

--- a/dasdutil.c
+++ b/dasdutil.c
@@ -177,7 +177,7 @@ static void do_data_dump( bool ascii, void* addr, unsigned int len, unsigned int
                 if (!ascii)
                     c = guest_to_host(c);
 
-                if (isprint(c))
+                if (isprint((unsigned char)c))
                     print_chars[i] = c;
             }
 
@@ -582,7 +582,7 @@ char            pathname[MAX_PATH];     /* file path in host format  */
         char *p;
         for (p = rmtdev + 1; *p && *p != ':'; p++)
         {
-            if (!isdigit(*p))  /* (port numbers are always numeric) */
+            if (!isdigit((unsigned char)*p))  /* (port numbers are always numeric) */
             {
                 /* Not a port number ==> not really a remote device */
                 rmtdev = NULL;
@@ -2385,7 +2385,7 @@ DLL_EXPORT int valid_dsname( const char *pszdsname )
     for ( i = 0; i < iLen; i++ )
     {
         BYTE c = pszdsname[i];
-        if ( isalnum( c ) )
+        if ( isalnum( (unsigned char)c ) )
             continue;
         else if ( c == '$' )
             continue;

--- a/dasdutil64.c
+++ b/dasdutil64.c
@@ -77,7 +77,7 @@ char            pathname[MAX_PATH];     /* file path in host format  */
         char *p;
         for (p = rmtdev + 1; *p && *p != ':'; p++)
         {
-            if (!isdigit(*p))  /* (port numbers are always numeric) */
+            if (!isdigit((unsigned char)*p))  /* (port numbers are always numeric) */
             {
                 /* Not a port number ==> not really a remote device */
                 rmtdev = NULL;

--- a/dmap2hrc.c
+++ b/dmap2hrc.c
@@ -176,7 +176,7 @@ char            pathname[MAX_PATH];     /* file path in host format  */
             /* It's a real device. Fix the type so Hercules can use it and
                locate the output filename. */
             STRLCPY( output_type, device.type );
-            if (isprint(device.parms.disk.volser[0]))
+            if (isprint((unsigned char)device.parms.disk.volser[0]))
                 output_filename = device.parms.disk.filename;
             else output_filename = device.parms.other.filename;
 

--- a/dyncrypt.c
+++ b/dyncrypt.c
@@ -109,7 +109,7 @@ static const int kmctr_pblens[32] =
   snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), " | "); \
   for(i = 0; i < (x); i++) \
   { \
-    if(isprint(guest_to_host((v)[i]))) \
+    if(isprint((unsigned char)guest_to_host((v)[i]))) \
       snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%c", guest_to_host((v)[i])); \
     else \
       snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "."); \
@@ -137,7 +137,7 @@ static const int kmctr_pblens[32] =
     snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), " | "); \
     for(j = 0; j < (x); j++) \
     { \
-      if(isprint(guest_to_host((v)[i * (x) + j]))) \
+      if(isprint((unsigned char)guest_to_host((v)[i * (x) + j]))) \
         snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%c", guest_to_host((v)[i * (x) + j])); \
       else \
         snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "."); \

--- a/facility.c
+++ b/facility.c
@@ -1762,7 +1762,7 @@ bool facility_query( int argc, char* argv[] )
         p += 3;
 
     if (1
-        && isdigit( *p )
+        && isdigit( (unsigned char)*p )
         && sscanf( p, "%d%c", &bitno, &c ) == 1
         && bitno >= 0
         && bitno <= (int) STFL_HERC_LAST_BIT
@@ -4516,7 +4516,7 @@ int facility_enable_disable( int argc, char* argv[] )
             p += 3;
 
         if (0
-            || !isdigit( *p )
+            || !isdigit( (unsigned char)*p )
             || sscanf( p, "%d%c", &bitno, &c ) != 1
             || bitno < 0
             || bitno > (int) STFL_HERC_LAST_BIT

--- a/hao.c
+++ b/hao.c
@@ -807,9 +807,9 @@ static void hao_message(char *buf)
                         continue;
                     }
                     /* replace $1..$99 by the corresponding capturing group */
-                    if (*p == '$' && isdigit(p[1]))
+                    if (*p == '$' && isdigit((unsigned char)p[1]))
                     {
-                        if (isdigit(p[2]))
+                        if (isdigit((unsigned char)p[2]))
                         {
                             j = (p[1]-'0') * 10 + (p[2]-'0');
                             k = 3;

--- a/hdl.c
+++ b/hdl.c
@@ -1100,7 +1100,7 @@ static const char* hdl_build_devmod_name( const char* typname )
     strlcat( dtname, typname, size );
 
     for (len = 0; len < strlen( dtname ); len++)
-        dtname[ len ] = tolower( dtname[ len ]);
+        dtname[ len ] = tolower( (unsigned char)dtname[ len ]);
 
     return dtname;
 }

--- a/hetinit.c
+++ b/hetinit.c
@@ -46,7 +46,7 @@ void het_string_to_upper (char *source)
 int i;
 
     for (i = 0; source[i] != '\0'; i++)
-        source[i] = toupper(source[i]);
+        source[i] = toupper((unsigned char)source[i]);
 }
 
 /*

--- a/hetmap.c
+++ b/hetmap.c
@@ -656,7 +656,7 @@ Print_Standard_Labels (void )
     TERMINATE(lLblType);
     TERMINATE(lLblNum);
 
-    if ( isdigit( lLblNum[0] ) )
+    if ( isdigit( (unsigned char)lLblNum[0] ) )
     { if ( lLblNum[0] < '1' || lLblNum[0] > '9' ) return ( FALSE ); } /* this should be transportable to EBCDIC machines */
     else
         return ( FALSE );
@@ -747,7 +747,7 @@ Print_Standard_Labels (void )
 
                     if ( lLblType[0] == 'E' )
                     {
-                        for ( i = 0; i < 4; i++ ) { if ( !isdigit( ebcnt[i] ) ) ebcnt[i] = '0'; }
+                        for ( i = 0; i < 4; i++ ) { if ( !isdigit( (unsigned char)ebcnt[i] ) ) ebcnt[i] = '0'; }
                         ebcnt[4] = '\0';
                     }
                     else

--- a/hsccmd.c
+++ b/hsccmd.c
@@ -3284,7 +3284,7 @@ char *strtok_str = NULL;
         for (cpu = 0; styp != NULL; )
         {
             count = 1;
-            if (isdigit(styp[0]))
+            if (isdigit((unsigned char)styp[0]))
             {
                 if (0
                     || sscanf(styp, "%d%c", &count, &c) != 2
@@ -3578,7 +3578,7 @@ int mainsize_cmd( int argc, char* argv[], char* cmdline )
 
         if (rc == 2)
         {
-            switch (toupper( f ))
+            switch (toupper( (unsigned char)f ))
             {
             case 'B':
                 suffix_oflow_mask = 0;
@@ -3740,7 +3740,7 @@ u_int   locktype = 0;
                                                             : sizeof(U32);
         if ( rc == 2 )
         {
-            switch (toupper(f))
+            switch (toupper((unsigned char)f))
             {
             case 'B':
                 shiftsize >>= SHIFT_MEBIBYTE;
@@ -4197,7 +4197,7 @@ int cnslport_cmd( int argc, char* argv[], char* cmdline )
 
         for (i=0; i < (int) strlen( port ); i++)
         {
-            if (!isdigit( port[i] ))
+            if (!isdigit( (unsigned char)port[i] ))
             {
                 // "Invalid value %s specified for %s"
                 WRMSG( HHC01451, "E", port, argv[0] );
@@ -4340,7 +4340,7 @@ int sysgport_cmd( int argc, char* argv[], char* cmdline )
 
             for (i=0; i < (int) strlen( port ); i++)
             {
-                if (!isdigit( port[i] ))
+                if (!isdigit( (unsigned char)port[i] ))
                 {
                     // "Invalid value %s specified for %s"
                     WRMSG( HHC01451, "E", port, argv[0] );
@@ -4729,7 +4729,7 @@ int sh_cmd( int argc, char* argv[], char* cmdline )
         return -1;
     }
 
-    for (cmdline += 2; isspace( *cmdline ); ++cmdline) /* (nop) */;
+    for (cmdline += 2; isspace( (unsigned char)*cmdline ); ++cmdline) /* (nop) */;
     return (*cmdline) ? herc_system( cmdline ) : -1;
 }
 
@@ -5113,8 +5113,8 @@ int stsi_model_cmd( int argc, char* argv[], char* cmdline )
             {
                 for (i=0; i < len; i++)
                 {
-                    if (!isalnum( model[m][i] ) ||
-                       (!isupper( model[m][i] ) && !isdigit( model[m][i] )))
+                    if (!isalnum( (unsigned char)model[m][i] ) ||
+                       (!isupper( (unsigned char)model[m][i] ) && !isdigit( (unsigned char)model[m][i] )))
                     {
                         char msgbuf[64];
                         MSGBUF( msgbuf, "%s-model = <%s>", model_name[m], model[m] );
@@ -5205,8 +5205,8 @@ int stsi_plant_cmd( int argc, char* argv[], char* cmdline )
 
         for (i=0; i < strlen( argv[1] ); i++)
         {
-            if (isalnum( argv[1][i] ) &&
-               (isupper( argv[1][i] ) || isdigit( argv[1][i] )))
+            if (isalnum( (unsigned char)argv[1][i] ) &&
+               (isupper( (unsigned char)argv[1][i] ) || isdigit( (unsigned char)argv[1][i] )))
                 continue;
 
             // "Invalid argument %s%s"
@@ -5263,8 +5263,8 @@ int stsi_manufacturer_cmd( int argc, char* argv[], char* cmdline )
 
         for (i=0; i < strlen( argv[1] ); i++)
         {
-            if (isalnum( argv[1][i] ) &&
-               (isupper( argv[1][i] ) || isdigit( argv[1][i] )))
+            if (isalnum( (unsigned char)argv[1][i] ) &&
+               (isupper( (unsigned char)argv[1][i] ) || isdigit( (unsigned char)argv[1][i] )))
                 continue;
 
             // "Invalid argument %s%s"
@@ -6365,7 +6365,7 @@ int qd_cmd( int argc, char* argv[], char* cmdline )
                 if (j % 4 == 0)
                     len += sprintf( buf + len, " " );
                 len += sprintf( buf + len, "%2.2X", iobuf[j] );
-                cbuf[ j % 16 ] = isprint( guest_to_host( iobuf[j] )) ? guest_to_host( iobuf[j] ) : '.';
+                cbuf[ j % 16 ] = isprint( (unsigned char)guest_to_host( iobuf[j] )) ? guest_to_host( iobuf[j] ) : '.';
             }
             len += sprintf( buf + len, " |%s|", cbuf );
             // "%s" // qd command
@@ -7200,7 +7200,7 @@ BYTE     unitstat, code = 0;
     {
         for (rc = 0; rc < (int)strlen(argv[3]); rc++)
         {
-            if ( !isdigit(argv[3][rc]) )
+            if ( !isdigit((unsigned char)argv[3][rc]) )
             {
                 WRMSG( HHC02205, "E", argv[3], "; not in range of 1-9999");
                 return -1;

--- a/hscemode.c
+++ b/hscemode.c
@@ -1237,7 +1237,7 @@ int trace_cmd( int argc, char* argv[], char* cmdline )
     bool  update  =  false;             /* Whether parms were given  */
     bool  unlock  =  false;             /* Should do RELEASE_INTLOCK */
 
-    cmdline[0] = tolower( cmdline[0] );
+    cmdline[0] = tolower( (unsigned char)cmdline[0] );
 
     trace  = (cmdline[0] == 't');       // trace command
     step   = (cmdline[0] == 's');       // stepping command

--- a/hscloc.c
+++ b/hscloc.c
@@ -95,7 +95,7 @@ void fmt_line( unsigned char *tbl, char *name, int start, int length)
             if ( (i & 0xf) == 0x0 ) { hbuf[j++] = SPACE; cbuf[k++] = SPACE; }
 
             j += idx_snprintf( j, hbuf, sizeof(hbuf), "%2.2X", c );
-            cbuf[k++] = ( !isprint(c) ? '.' : c );
+            cbuf[k++] = ( !isprint((unsigned char)c) ? '.' : c );
 
         } /* end for(i) */
         MSGBUF( fmtline, "%s+0x%04x%-74.74s %-34.34s", name, o, hbuf, cbuf );

--- a/hscmisc.c
+++ b/hscmisc.c
@@ -168,7 +168,7 @@ BYTE    c;                              /* Character work area       */
             hbuf[++j] = 0;
         }
         c = guest_to_host(c);
-        if (!isprint(c)) c = '.';
+        if (!isprint((unsigned char)c)) c = '.';
         cbuf[i] = c;
         if ((aaddr & PAGEFRAME_BYTEMASK) == 0x000) break;
     } /* end for(i) */
@@ -357,7 +357,7 @@ char    buf[512];                       /* MSGBUF work buffer        */
 
     /* Parse optional address-space prefix */
     opnd = argv[0];
-    type = toupper( *opnd );
+    type = toupper( (unsigned char)*opnd );
 
     if (0
         || type == 'R'
@@ -487,7 +487,7 @@ char    absorr[8];                      /* Uppercase command         */
 
     /* Convert command to uppercase */
     for (i = 0; argv[0][i]; i++)
-        absorr[i] = toupper(argv[0][i]);
+        absorr[i] = toupper((unsigned char)argv[0][i]);
     absorr[i] = 0;
     opnd = argv[1];
 
@@ -653,7 +653,7 @@ size_t  totamt;                         /* Total amount to be dumped */
 
     /* Parse optional address-space prefix */
     opnd = argv[0];
-    type = toupper( *opnd );
+    type = toupper( (unsigned char)*opnd );
 
     if (1
         && type != 'P'
@@ -2130,7 +2130,7 @@ BYTE    c;                              /* Character work area       */
             h1 = *(++s);
             if (h1 == '\0'  || h1 == '#' ) break;
             if (h1 == SPACE || h1 == '\t') continue;
-            h1 = toupper(h1);
+            h1 = toupper((unsigned char)h1);
             h1 = (h1 >= '0' && h1 <= '9') ? h1 - '0' :
                  (h1 >= 'A' && h1 <= 'F') ? h1 - 'A' + 10 : -1;
             if (h1 < 0)
@@ -2139,7 +2139,7 @@ BYTE    c;                              /* Character work area       */
                 return -1;
             }
             h2 = *(++s);
-            h2 = toupper(h2);
+            h2 = toupper((unsigned char)h2);
             h2 = (h2 >= '0' && h2 <= '9') ? h2 - '0' :
                  (h2 >= 'A' && h2 <= 'F') ? h2 - 'A' + 10 : -1;
             if (h2 < 0)

--- a/hscpufun.c
+++ b/hscpufun.c
@@ -464,8 +464,8 @@ char*   loadparm     = NULL;            /* Pointer to LOADPARM arg   */
                     */
                     for (j=0, len = (int) strlen( argv[i] ); j < len && psi < SIZEOF_IPLPARM; j++)
                     {
-                        if (islower( argv[i][j] ))
-                            argv[i][j] = toupper( argv[i][j] );
+                        if (islower( (unsigned char)argv[i][j] ))
+                            argv[i][j] = toupper( (unsigned char)argv[i][j] );
 
                         sysblk.iplparmstring[ psi++ ] = host_to_guest( argv[i][j] );
                     }

--- a/hscutl.c
+++ b/hscutl.c
@@ -465,7 +465,7 @@ DLL_EXPORT char *resolve_symbol_string(const char *text)
             if (c == '\0' ) break;
 
             /* Check if it is a white space and no other character yet */
-            if(!lstarted && isspace(c)) continue;
+            if(!lstarted && isspace((unsigned char)c)) continue;
             lstarted=1;
 
             /* Check that statement does not overflow buffer */
@@ -1703,7 +1703,7 @@ DLL_EXPORT int parse_args( char* p, int maxargc, char** pargv, int* pargc )
 
     while (*p && *pargc < maxargc)
     {
-        while (*p && isspace(*p))
+        while (*p && isspace((unsigned char)*p))
         {
             p++;
         }
@@ -1721,7 +1721,7 @@ DLL_EXPORT int parse_args( char* p, int maxargc, char** pargv, int* pargc )
         *pargv = p;
         ++*pargc;
 
-        while (*p && !isspace(*p) && *p != '\"' && *p != '\'')
+        while (*p && !isspace((unsigned char)*p) && *p != '\"' && *p != '\'')
         {
             p++;
         }
@@ -1800,13 +1800,13 @@ DLL_EXPORT void string_to_upper( char* source )
 {
     int  i;
     for (i=0; source[i]; i++)
-        source[i] = toupper( source[i] );
+        source[i] = toupper( (unsigned char)source[i] );
 }
 DLL_EXPORT void string_to_lower( char* source )
 {
     int  i;
     for (i=0; source[i]; i++)
-        source[i] = tolower( source[i] );
+        source[i] = tolower( (unsigned char)source[i] );
 }
 
 /*-------------------------------------------------------------------*/

--- a/httpserv.c
+++ b/httpserv.c
@@ -403,7 +403,7 @@ static void http_verify_path(WEBBLK *webblk, char *path)
     int i;
 
     for (i = 0; path[i]; i++)
-        if (!isalnum((int)path[i]) && !strchr("/.-_", path[i]))
+        if (!isalnum((unsigned char)path[i]) && !strchr("/.-_", path[i]))
             http_error(webblk, "404 File Not Found","",
                                "Illegal character in filename");
 #endif

--- a/impl.c
+++ b/impl.c
@@ -1759,8 +1759,8 @@ static int process_args( int argc, char* argv[] )
 
                         for (j=0; j < (int) strlen( sym ); j++)
                         {
-                            if (islower( sym[j] ))
-                                sym[j] = toupper( sym[j] );
+                            if (islower( (unsigned char)sym[j] ))
+                                sym[j] = toupper( (unsigned char)sym[j] );
                         }
 
                         set_symbol( sym, value );
@@ -1849,7 +1849,7 @@ static int process_args( int argc, char* argv[] )
             {
                 char buf[16];
 
-                if (isprint( optopt ))
+                if (isprint( (unsigned char)optopt ))
                     MSGBUF( buf, "'-%c'", optopt );
                 else
                     MSGBUF( buf, "(hex %2.2x)", optopt );

--- a/loadparm.c
+++ b/loadparm.c
@@ -97,8 +97,8 @@ static GSYSINFO gsysinfo;
     if (_source) \
         { \
         for (; i < n; i++) \
-             if (isprint((_source)[i])) \
-                 _target[i] = host_to_guest((int)toupper((_source)[i])); \
+             if (isprint((unsigned char)(_source)[i])) \
+                 _target[i] = host_to_guest((int)toupper((unsigned char)(_source)[i])); \
              else \
                  _target[i] = 0x40; \
         } \
@@ -116,9 +116,9 @@ static GSYSINFO gsysinfo;
     BYTE    temp[sizeof(_target)]; \
     memset(temp, 0x40, sizeof(temp) ); \
     for (i = 0, n = 0; (_source) && i < strlen(_source) && i < sizeof(temp); i++) \
-        if (isalnum((_source)[i])) \
+        if (isalnum((unsigned char)(_source)[i])) \
         { \
-            temp[i] = host_to_guest((int)toupper((_source)[i])); \
+            temp[i] = host_to_guest((int)toupper((unsigned char)(_source)[i])); \
             n++; \
         } \
         else \
@@ -180,9 +180,9 @@ static int copy_stringz_to_ebcdic(BYTE* fld, size_t len, char *name)
     copylen = MIN(strlen(name), len);
 
     for ( i = 0, n = 0; i < copylen; i++ )
-        if ( isalnum(name[i]) )
+        if ( isalnum((unsigned char)name[i]) )
         {
-            temp_fld[i] = host_to_guest((int)toupper(name[i]));
+            temp_fld[i] = host_to_guest((int)toupper((unsigned char)name[i]));
             n++;
         }
         else
@@ -217,7 +217,7 @@ static int copy_ebcdic_to_stringz(char *name, size_t nlen, BYTE* fld, size_t fle
     {
         c = guest_to_host(fld[i]);
 
-        if ( c == SPACE || !isalnum(c) )
+        if ( c == SPACE || !isalnum((unsigned char)c) )
             break; /* there should not be any embedded blanks */
 
         name[i] = c;

--- a/maketape.c
+++ b/maketape.c
@@ -772,7 +772,7 @@ int     i, j;                      /* used to index through string vars    */
 
     /* ensure that label fields only contain upper case */
     for (i=0; i < 80; i++)
-        buf[i] = toupper( buf[i] );
+        buf[i] = toupper( (unsigned char)buf[i] );
 
     if (!nltape)
     {
@@ -857,7 +857,7 @@ int     offset;                    /* used for building blocked records    */
 
         /* ensure that label fields only contain upper case */
         for (i=0; i < 80; i++)
-            buf[i] = toupper( buf[i] );
+            buf[i] = toupper( (unsigned char)buf[i] );
 
         if (ansi)
             buf[79] = '1';

--- a/mpc.c
+++ b/mpc.c
@@ -180,9 +180,9 @@ DLL_EXPORT void  mpc_display_stuff( DEVBLK* pDEVBLK, char* cWhat, BYTE* pAddr, i
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( isprint( (unsigned char)e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( isprint( (unsigned char)c ) )
                     print_ascii[i] = c;
             }
             else

--- a/panel.c
+++ b/panel.c
@@ -1424,7 +1424,7 @@ static void NP_update(REGS *regs)
                 l = (int)strlen(devnam);
                 for ( p = 0; p < l; p++ )
                 {
-                    if ( !isprint(devnam[p]) )
+                    if ( !isprint((unsigned char)devnam[p]) )
                     {
                         devnam[p] = '\0';
                         break;
@@ -2066,7 +2066,7 @@ size_t  loopcount;                      /* Number of iterations done */
                         case 1:                     /* IPL - 2nd part */
                             if (!sysblk.hicpu)
                               break;
-                            i = toupper(NPdevice) - 'A';
+                            i = toupper((unsigned char)NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2087,7 +2087,7 @@ size_t  loopcount;                      /* Number of iterations done */
                         case 2:                     /* Device int: part 2 */
                             if (!sysblk.hicpu)
                               break;
-                            i = toupper(NPdevice) - 'A';
+                            i = toupper((unsigned char)NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2106,7 +2106,7 @@ size_t  loopcount;                      /* Number of iterations done */
                             redraw_status = 1;
                             break;
                         case 3:                     /* Device asgn: part 2 */
-                            i = toupper(NPdevice) - 'A';
+                            i = toupper((unsigned char)NPdevice) - 'A';
                             if (i < 0 || i > NPlastdev) {
                                 memset(NPprompt2,0,sizeof(NPprompt2));
                                 redraw_status = 1;
@@ -2311,7 +2311,7 @@ size_t  loopcount;                      /* Number of iterations done */
 
                             while (*p && ncmd_tok < 10 )
                             {
-                                while (*p && isspace(*p))
+                                while (*p && isspace((unsigned char)*p))
                                 {
                                     p++;
                                 }
@@ -2325,7 +2325,7 @@ size_t  loopcount;                      /* Number of iterations done */
                                 cmd_tok[ncmd_tok] = p; ++ncmd_tok; // count new arg
 
                                 while ( *p
-                                        && !isspace(*p)
+                                        && !isspace((unsigned char)*p)
                                         && *p != '\"'
                                         && *p != '\'' )
                                 {
@@ -2410,7 +2410,7 @@ size_t  loopcount;                      /* Number of iterations done */
                                             }
                                         }
                                     }
-                                    else if ( !isdigit( pt1[idx+1] ) && ( pt1[idx+1] != '$' ) )
+                                    else if ( !isdigit( (unsigned char)pt1[idx+1] ) && ( pt1[idx+1] != '$' ) )
                                     {
                                         psz_cmdline[odx++] = pt1[idx];
                                     }
@@ -2786,7 +2786,7 @@ size_t  loopcount;                      /* Number of iterations done */
                 } /* end if (kbbuf[i] == '\n') */
 
                 /* Ignore non-printable characters */
-                if (!isprint(kbbuf[i])) {
+                if (!isprint((unsigned char)kbbuf[i])) {
                     beep();
                     i++;
                     continue;

--- a/printer.c
+++ b/printer.c
@@ -389,7 +389,7 @@ static BYTE WriteLine
         if (!c)
             c = SPACE;
         else if (dev->fold)
-            c = toupper(c);
+            c = toupper((unsigned char)c);
 
         /* Copy to device output buffer */
         dev->buf[ dev->bufoff ] = c;
@@ -1263,7 +1263,7 @@ int   fcbsize;                          /* FCB size for this devtype */
                 /* ':" NOT found. old format or fcb name */
                 char c;
                 ptr = argv[ iarg ] + 4; /* get past "fcb=" */
-                if (strlen( ptr ) != 26 || !isdigit( *ptr ))
+                if (strlen( ptr ) != 26 || !isdigit( (unsigned char)*ptr ))
                 {
                     /* It doesn't appear they're defining a custom
                        fcb. See if they gave us an fcb name instead.

--- a/qeth.c
+++ b/qeth.c
@@ -4289,7 +4289,7 @@ U32 mask4;
         {
             // Check whether a numeric prefix in the range 1 to 128 has been specified.
             work_rc = 0;
-            for (p = grp->ttpfxlen6; isdigit(*p); p++) { }
+            for (p = grp->ttpfxlen6; isdigit((unsigned char)*p); p++) { }
             if (*p != '\0' || !strlen(grp->ttpfxlen6))
                 work_rc = -1;
             pfxlen = atoi(grp->ttpfxlen6);
@@ -6535,7 +6535,7 @@ static int  prefix2netmask( char* ttpfxlen, char** ttnetmask )
     char* p;
     int pfxlen;
     /* make sure it's a number from 0 to 32 */
-    for (p = ttpfxlen; isdigit(*p); p++) { }
+    for (p = ttpfxlen; isdigit((unsigned char)*p); p++) { }
     if (*p || !ttpfxlen[0] || (pfxlen = atoi(ttpfxlen)) > 32)
         return -1;
     addr4.s_addr = ~makepfxmask4( ttpfxlen );

--- a/scescsi.c
+++ b/scescsi.c
@@ -856,7 +856,7 @@ int n;
 
         if(!(!ntf->name
           && !strncasecmp("type",argv[1],4)
-          && isdigit(*(argv[1]+4))
+          && isdigit((unsigned char)*(argv[1]+4))
           && sscanf(argv[1]+4, "%u%c", &file, &c) == 1
           && file < HWL_MAXFILETYPE))
         {
@@ -912,7 +912,7 @@ int lddev_cmd( int argc, char* argv[], char* cmdline )
     UNREFERENCED(cmdline);
 
     // [0] = LOAD, [1] = DUMP
-    ldind = ((islower(*argv[0]) ? toupper(*argv[0]) : *argv[0] ) == 'L')
+    ldind = ((islower((unsigned char)*argv[0]) ? toupper((unsigned char)*argv[0]) : *argv[0] ) == 'L')
           ? 0 : 1;
 
     if(argc > 1)

--- a/script.c
+++ b/script.c
@@ -810,7 +810,7 @@ int     rc;                             /* (work)                    */
 #if defined(HAVE_OBJECT_REXX) || defined(HAVE_REGINA_REXX)
 
     /* Skip past blanks to start of command */
-    for (p = stmt; isspace( *p ); p++)
+    for (p = stmt; isspace( (unsigned char)*p ); p++)
         ; /* (nop; do nothing) */
 
     /* Execute REXX script if line begins with "Slash '/' Asterisk '*'" */
@@ -832,11 +832,11 @@ int     rc;                             /* (work)                    */
         stmtnum++;
 
         /* Skip past blanks to start of statement */
-        for (p = stmt; isspace( *p ); p++)
+        for (p = stmt; isspace( (unsigned char)*p ); p++)
             ; /* (nop; do nothing) */
 
         /* Remove trailing whitespace */
-        for (stmtlen = (int)strlen(p); stmtlen && isspace(p[stmtlen-1]); stmtlen--);
+        for (stmtlen = (int)strlen(p); stmtlen && isspace((unsigned char)p[stmtlen-1]); stmtlen--);
         p[stmtlen] = 0;
 
         /* Special handling for 'pause' and other statements */
@@ -1052,7 +1052,7 @@ int runtest( SCRCTL *pCtl, char *cmdline, char *args )
         if (p2)
             args = p2;
 
-        if (isalpha( args[0] ))  /* [RESTART|START|<oldpsw>]? */
+        if (isalpha( (unsigned char)args[0] ))  /* [RESTART|START|<oldpsw>]? */
         {
 #define MAX_KW_LEN 15
             char kw[ MAX_KW_LEN + 1 ] = {0};

--- a/service.c
+++ b/service.c
@@ -247,7 +247,7 @@ static void gh534_fix( int msglen, BYTE* /*EBCDIC*/ e_msg )
     /* Lastly, convert any unprintable chars to spaces or underscores */
     for (i=0; a_msg[i]; i++)
     {
-        if (!isprint( a_msg[i] ))
+        if (!isprint( (unsigned char)a_msg[i] ))
         {
             if (a_msg[i] == subsub[0])  // "SUB" character?
                 a_msg[i] = '_';         // Replace with underscore
@@ -1984,7 +1984,7 @@ fflush( efile );
                             {
                                 for (i=0; i < event_msglen; i++)
                                 {
-                                    message[i] = isprint( guest_to_host( evd_msg[i] )) ?
+                                    message[i] = isprint( (unsigned char)guest_to_host( evd_msg[i] )) ?
                                         guest_to_host( evd_msg[i] ) : ' ';
                                 }
                                 message[i] = '\0';

--- a/sllib.c
+++ b/sllib.c
@@ -1158,13 +1158,13 @@ sl_ds1( SLLABEL *lab,
         gdg  = 0;
         gdg += (          dsn[ len - 9 ]   == '.' );
         gdg += (          dsn[ len - 8 ]   == 'G' );
-        gdg += ( isdigit( dsn[ len - 7 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 6 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 5 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 4 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 7 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 6 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 5 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 4 ] ) !=  0  );
         gdg += (          dsn[ len - 3 ]   == 'V' );
-        gdg += ( isdigit( dsn[ len - 2 ] ) !=  0  );
-        gdg += ( isdigit( dsn[ len - 1 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 2 ] ) !=  0  );
+        gdg += ( isdigit( (unsigned char)dsn[ len - 1 ] ) !=  0  );
 
         if( gdg == 9 )
         {

--- a/sockdev.c
+++ b/sockdev.c
@@ -172,7 +172,7 @@ int inet_socket( char* spec )
         memcpy( &sin.sin_addr, he->h_addr_list[0], sizeof( sin.sin_addr ));
     }
 
-    if (isdigit( service[0] ))
+    if (isdigit( (unsigned char)service[0] ))
     {
         sin.sin_port = htons( atoi( service ));
     }

--- a/sr.c
+++ b/sr.c
@@ -449,7 +449,7 @@ int      numconfdev=0;
             if (len >= 2)
             {
                 len -= 2;
-                while (len > 0 && isspace(buf[len]))
+                while (len > 0 && isspace((unsigned char)buf[len]))
                     --len;
                 buf[len+1]=0;
             }

--- a/tapedev.c
+++ b/tapedev.c
@@ -1527,7 +1527,7 @@ int  mountnewtape ( DEVBLK *dev, int argc, char **argv )
                 }
                 else if ( rc == 2 )
                 {
-                    switch (toupper(f))
+                    switch (toupper((unsigned char)f))
                     {
                         case 'K':
                             maxsize <<= SHIFT_KIBIBYTE;
@@ -1590,7 +1590,7 @@ int  mountnewtape ( DEVBLK *dev, int argc, char **argv )
                 }
                 else if ( rc == 2 )
                 {
-                    switch (toupper(f))
+                    switch (toupper((unsigned char)f))
                     {
                         case 'K':
                             eotmargin <<= SHIFT_KIBIBYTE;

--- a/tcpnje.c
+++ b/tcpnje.c
@@ -179,7 +179,7 @@ static void logdump(char *txt, DEVBLK *dev, BYTE *bfr, size_t sz)
         for(j = 0; (j < 16) && ((i + j) < sz); j++)
         {
             character = guest_to_host(bfr[i + j]);
-            if (!isprint(character)) character = '.';
+            if (!isprint((unsigned char)character)) character = '.';
             logmsg("%c", character);
         }
         logmsg("\n");
@@ -202,7 +202,7 @@ static char *guest_to_host_string(char *string, size_t length, const BYTE *ebcdi
 
         if (string[i] == ' ')
             string[i] = '\0';
-        else if (!isprint(string[i]))
+        else if (!isprint((unsigned char)string[i]))
             string[i] = '.';
     }
 
@@ -2584,7 +2584,7 @@ static int tcpnje_init_handler(DEVBLK *dev, int argc, char *argv[])
                     }
                     for(j = 0; j < strlen(res.text); j++)
                     {
-                        tn->lnode[j] = host_to_guest(toupper(res.text[j]));
+                        tn->lnode[j] = host_to_guest(toupper((unsigned char)res.text[j]));
                     }
                     break;
                 case TCPNJE_KW_RNODE:
@@ -2596,7 +2596,7 @@ static int tcpnje_init_handler(DEVBLK *dev, int argc, char *argv[])
                     }
                     for(j = 0; j < strlen(res.text); j++)
                     {
-                        tn->rnode[j] = host_to_guest(toupper(res.text[j]));
+                        tn->rnode[j] = host_to_guest(toupper((unsigned char)res.text[j]));
                     }
                     break;
                 case TCPNJE_KW_DEBUG:

--- a/tfprint.c
+++ b/tfprint.c
@@ -1767,7 +1767,7 @@ static inline void print_op_stor( const char* pfx, BYTE arch_mode, BYTE real_mod
         for (i=0; i < op->amt; i++)
         {
             c = guest_to_host( op->stor[ i ]);
-            if (!isprint( c )) c = '.';
+            if (!isprint( (unsigned char)c )) c = '.';
             cbuf[ i ] = c;
         }
 
@@ -3564,7 +3564,7 @@ static bool convert_storage_opt_str( bool ishex, const char* str, U64* pU64, MOP
 
     if (str[1] == ':')
     {
-        char str0 = toupper( str[0] );
+        char str0 = toupper( (unsigned char)str[0] );
 
         if (1
             && str0 != 'V'      // Virtual address?
@@ -3829,7 +3829,7 @@ static bool convert_opcode_opt_str( bool ishex, const char* str, U64* pU64, MOPT
 
     for (i=0; i < n; i += 2)
     {
-        c = toupper( str[i] );      // Left nibble
+        c = toupper( (unsigned char)str[i] );      // Left nibble
 
         if (is_hex_l( &c, 1 ))
         {
@@ -3844,7 +3844,7 @@ static bool convert_opcode_opt_str( bool ishex, const char* str, U64* pU64, MOPT
             left_mask = 0;
         }
 
-        c = toupper( str[i+1] );    // Right nibble
+        c = toupper( (unsigned char)str[i+1] );    // Right nibble
 
         if (is_hex_l( &c, 1 ))
         {

--- a/tuntap.c
+++ b/tuntap.c
@@ -1309,8 +1309,8 @@ int  ParseMAC( char* pszMACAddr, BYTE* pbMACAddr )
     {
         if
         (0
-            || !isxdigit(work[(i*3)+0])
-            || !isxdigit(work[(i*3)+1])
+            || !isxdigit((unsigned char)work[(i*3)+0])
+            || !isxdigit((unsigned char)work[(i*3)+1])
             ||  sep  !=  work[(i*3)+2]
         )
         {
@@ -1422,9 +1422,9 @@ void net_data_trace( DEVBLK* pDEVBLK, BYTE* pAddr, int iLen, BYTE bDir, BYTE bSe
                 print_ebcdic[i] = print_ascii[i] = '.';
                 e = guest_to_host( c );
 
-                if( isprint( e ) )
+                if( isprint( (unsigned char)e ) )
                     print_ebcdic[i] = e;
-                if( isprint( c ) )
+                if( isprint( (unsigned char)c ) )
                     print_ascii[i] = c;
             }
             else

--- a/vm.c
+++ b/vm.c
@@ -1000,7 +1000,7 @@ BYTE       c;                           /* Character work area       */
     for (i = 0; i < 8; i++)
     {
         c = (*puser == '\0' ? SPACE : *(puser++));
-        buf[16+i] = host_to_guest(toupper(c));
+        buf[16+i] = host_to_guest(toupper((unsigned char)c));
     }
 
     /* Bytes 24-31 contain the program product bitmap */

--- a/vmfplc2.c
+++ b/vmfplc2.c
@@ -1560,7 +1560,7 @@ static const char* validate_cmsfile( const char* fn, const char* ft, const char*
         return msg;
     }
 
-    if (!isalpha( fm[0] ))
+    if (!isalpha( (unsigned char)fm[0] ))
         return "CMS File mode must start with a letter";
 
     if (strlen( fm ) > 1)
@@ -1838,8 +1838,8 @@ static int parse_ctlfile_stmt( OPTIONS* opts, const char* orec, int recno )
     ctl.hostfile = strdup( infile );
     ctl.mtime    = stt.st_mtime;
     ctl.reclen   = reclen;
-    ctl.recfm    = toupper( recfm  [0] );
-    ctl.filefmt  = toupper( filefmt[0] );
+    ctl.recfm    = toupper( (unsigned char)recfm  [0] );
+    ctl.filefmt  = toupper( (unsigned char)filefmt[0] );
     ctl.loaded   = false;
 
     VERIFY( add_ctltab_entry( &ctl ));

--- a/w32ctca.c
+++ b/w32ctca.c
@@ -119,7 +119,7 @@ void __cdecl tt32_output_debug_string( const char* debug_string )
         *p2 && (nl2 = nl = strchr( p2, '\n' )); p2 = nl+1)
     {
         // Remove trailing whitespace to conform to Hercules logmsg format.
-        for (; nl2 >= p2 && isspace(*nl2); --nl2)
+        for (; nl2 >= p2 && isspace((unsigned char)*nl2); --nl2)
             *nl2 = 0;
         if (*p2)
             // "DBG: %s"

--- a/w32stape.c
+++ b/w32stape.c
@@ -202,7 +202,7 @@ ufd_t w32_open_tape ( const char* path, int oflag, ... )
                     strnfilenamecmp( (pszTapeDevNum=path+7)-2, "st",  2 ) == 0
                 )
             &&  strlen(pszTapeDevNum) == 1
-            &&  isdigit(*pszTapeDevNum)
+            &&  isdigit((unsigned char)*pszTapeDevNum)
         )
         {
             // Change it to a Windows device name (e.g. \\.\Tape0)

--- a/w32util.c
+++ b/w32util.c
@@ -1314,7 +1314,7 @@ DLL_EXPORT BYTE *hostpath( BYTE *outpath, const BYTE *inpath, size_t buffsize )
         if (1
             && inlen >= 11
             && strncasecmp((const char *)inpath,"/cygdrive/",10) == 0
-            && isalpha(inpath[10])
+            && isalpha((unsigned char)inpath[10])
         )
         {
             *outpath++ = inpath[10];
@@ -4238,7 +4238,7 @@ DLL_EXPORT pid_t w32_poor_mans_fork ( char* pszCommandLine, int* pnWriteToChildS
 
         // Now print ALL captured messages AT ONCE (if any)...
 
-        while (pPipedProcessCtl->nStrLen && isspace( pPipedProcessCtl->pszBuffer[ pPipedProcessCtl->nStrLen - 1 ] ))
+        while (pPipedProcessCtl->nStrLen && isspace( (unsigned char)pPipedProcessCtl->pszBuffer[ pPipedProcessCtl->nStrLen - 1 ] ))
             pPipedProcessCtl->nStrLen--;
         if (pPipedProcessCtl->nStrLen)
         {
@@ -4387,7 +4387,7 @@ void w32_parse_piped_process_stdxxx_data ( PIPED_PROCESS_CTL* pPipedProcessCtl, 
         *pend = 0;                      // (change newline character to null)
         pmsgend = pend;                 // (start removing blanks from here)
 
-        while (--pmsgend >= pbeg && isspace(*pmsgend)) {*pmsgend = 0; --nlen;}
+        while (--pmsgend >= pbeg && isspace((unsigned char)*pmsgend)) {*pmsgend = 0; --nlen;}
 
         // If we were passed a PIPED_PROCESS_CTL pointer, then the root thread
         // wants us to just capture the o/p and IT will issue the logmsg within
@@ -4644,10 +4644,10 @@ DLL_EXPORT char*  w32_strcasestr( const char* haystack, const char* needle )
 
     while ( haystack[++i] != '\0' )
     {
-        if ( tolower( haystack[i] ) == tolower( needle[0] ) )
+        if ( tolower( (unsigned char)haystack[i] ) == tolower( (unsigned char)needle[0] ) )
         {
             int j=i, k=0, match=0;
-            while ( tolower( haystack[++j] ) == tolower( needle[++k] ) )
+            while ( tolower( (unsigned char)haystack[++j] ) == tolower( (unsigned char)needle[++k] ) )
             {
                 match=1;
                 // Catch case when they match at the end


### PR DESCRIPTION
Compiling Hercules with gcc 10 produces many warnings like this one:
```
  CC       hao.lo
In file included from /usr/include/ctype.h:97,
                 from hstdinc.h:117,
                 from hao.c:17:
hao.c: In function 'hao_message':
hao.c:812:37: warning: array subscript has type 'char' [-Wchar-subscripts]
  812 |                         if (isdigit(p[2]))
      |                             ^
```
Gcc should really present these as compile time errors, since each and every one represents a potential case of Undefined Behaviour. I changed (almost) all of these calls, except a few where the parameter was an int that just came from a getc()-type function.
NetBSD's ctype manual page explains extensively:
```
CAVEATS
     The argument of these functions is of type int, but only a very
     restricted subset of values are actually valid.  The argument must either
     be the value of the macro EOF (which has a negative value), or must be a
     non-negative value within the range representable as unsigned char.
     Passing invalid values leads to undefined behavior.

     Values of type int that were returned by getc(3), fgetc(3), and similar
     functions or macros are already in the correct range, and may be safely
     passed to these ctype functions without any casts.

     Values of type char or signed char must first be cast to unsigned char,
     to ensure that the values are within the correct range.  Casting a
     negative-valued char or signed char directly to int will produce a
     negative-valued int, which will be outside the range of allowed values
     (unless it happens to be equal to EOF, but even that would not give the
     desired result).

     Because the bugs may manifest as silent misbehavior or as crashes only
     when fed input outside the US-ASCII range, the NetBSD implementation of
     the ctype functions is designed to elicit a compiler warning for code
     that passes inputs of type char in order to flag code that may pass
     negative values at runtime that would lead to undefined behavior:

           #include <ctype.h>
           #include <locale.h>
           #include <stdio.h>

           int
           main(int argc, char **argv)
           {

                   if (argc < 2)
                           return 1;
                   setlocale(LC_ALL, "");
                   printf("%d %d\n", *argv[1], isprint(*argv[1]));
                   printf("%d %d\n", (int)(unsigned char)*argv[1],
                       isprint((unsigned char)*argv[1]));
                   return 0;
           }

     When compiling this program, GCC reports a warning for the line that
     passes char.  At runtime, you may get nonsense answers for some inputs
     without the cast -- if you're lucky and it doesn't crash:

           % gcc -Wall -o test test.c
           test.c: In function 'main':
           test.c:12:2: warning: array subscript has type 'char'
           % LC_CTYPE=C ./test $(printf '\270')
           -72 5
           184 0
           % LC_CTYPE=C ./test $(printf '\377')
           -1 0
           255 0
           % LC_CTYPE=fr_FR.ISO8859-1 ./test $(printf '\377')
           -1 0
           255 2

     Some implementations of libc, such as glibc as of 2018, attempt to avoid
     the worst of the undefined behavior by defining the functions to work for
     all integer inputs representable by either unsigned char or char, and
     suppress the warning.  However, this is not an excuse for avoiding
     conversion to unsigned char: if EOF coincides with any such value, as it
     does when it is -1 on platforms with signed char, programs that pass char
     will still necessarily confuse the classification and mapping of EOF with
     the classification and mapping of some non-EOF inputs.

NetBSD 9.3                     January 15, 2019                     NetBSD 9.3
```