### PR TITLE
Make an inline function also static.

### DIFF
--- a/inline.h
+++ b/inline.h
@@ -542,7 +542,7 @@ inline BYTE* ARCH_DEP( fetch_main_absolute )( RADR addr, REGS* regs )
 /*-------------------------------------------------------------------*/
 /*  Generate a PER 1 General Register Alteration event interrupt     */
 /*-------------------------------------------------------------------*/
-inline void ARCH_DEP( per1_gra )( REGS* regs )
+static inline void ARCH_DEP( per1_gra )( REGS* regs )
 {
 #if !defined( FEATURE_PER1 )
     UNREFERENCED( regs );


### PR DESCRIPTION
gcc 10 warns many times like so:
```
  CC       chsc.lo
In file included from hercules.h:105,
                 from chsc.c:21:
hinlines.h:342:33: warning: 'Release_Interrupt_Lock' is static but used in inline function 's370_per1_gra' which is not static
  342 | #define RELEASE_INTLOCK(r)      Release_Interrupt_Lock( r, PTT_LOC )
      |                                 ^~~~~~~~~~~~~~~~~~~~~~
inline.h:555:5: note: in expansion of macro 'RELEASE_INTLOCK'
  555 |     RELEASE_INTLOCK( regs );
      |     ^~~~~~~~~~~~~~~
hinlines.h:341:33: warning: 'Obtain_Interrupt_Lock' is static but used in inline function 's370_per1_gra' which is not static
  341 | #define OBTAIN_INTLOCK(r)       Obtain_Interrupt_Lock( r, PTT_LOC )
      |                                 ^~~~~~~~~~~~~~~~~~~~~
inline.h:550:5: note: in expansion of macro 'OBTAIN_INTLOCK'
  550 |     OBTAIN_INTLOCK( regs );
      |     ^~~~~~~~~~~~~~
```
and by cleaning up these warnings we are now almost warning-free, and the remaining ones stand out and can be found and treated more easily. It turns out (from simply trying to compile it) that `inline void ARCH_DEP( per1_gra )( REGS* regs )` can easily be `static`. Which is not so strange since it's defined in a header.