### PR TITLE
Fix remaining warnings

### DIFF
--- a/cckddasd.c
+++ b/cckddasd.c
@@ -6714,7 +6714,7 @@ void cckd_trace( const char* func, int line, DEVBLK* dev, char* fmt, ... )
 
             "%s.%6.6ld %1d:%04X ",          // "hh:mm:ss.uuuuuu n:CCUU "
             todwrk + 11,                    // "hh:mm:ss" (%s)
-            timeval.tv_usec,                // "uuuuuu"   (%6.6ld
+            (long int)timeval.tv_usec,      // "uuuuuu"   (%6.6ld
             LCSS_DEVNUM                     // "n:CCUU"   (%1d:%04X)
         );
 

--- a/config.c
+++ b/config.c
@@ -1076,7 +1076,7 @@ int configure_cpu( int target_cpu )
         /* provided the _POSIX_THREAD_CPUTIME is supported.                       */
         pthread_getcpuclockid( sysblk.cputid[ target_cpu ], &sysblk.cpuclockid[ target_cpu ]);
         if (!sysblk.hhc_111_112)
-            WRMSG( HHC00111, "I", _POSIX_THREAD_CPUTIME );
+            WRMSG( HHC00111, "I", (long int)_POSIX_THREAD_CPUTIME );
 #else
         /* When not supported, we zero the cpuclockid, which will trigger a       */
         /* different approach to obtain the thread CPU time in clock.c            */

--- a/dasdload2.h
+++ b/dasdload2.h
@@ -2846,7 +2846,7 @@ char            pathname[MAX_PATH];     /* xfname in host path format*/
                 return -1;
             }
 
-            // "Input record:   CCHHR[%04X%04X%02X] (TTR[%04X%02X]) kl[%d] dl[%d]\n" \
+            // "Input record:   CCHHR[%04X%04X%02X] (TTR[%04X%02X]) kl[%d] dl[%d]\n"
             //       "HHC02564I relocated to:   CCHHR[%04X%04X%02X] (TTR[%04X%02X])"
             XMINFF (4, MSG( HHC02564, "I", blkcyl, blkhead, blkrec, blktrk, blkrec, keylen, datalen,
                                            outcyl, outhead, outrec, outtrk, outrec ) );

--- a/hRexx.c
+++ b/hRexx.c
@@ -951,11 +951,11 @@ int rexx_cmd( int argc, char* argv[], char* cmdline )
                         return CancelAllRexxExecs() ? 0 : -1;
                     else
                     {
-                        TID tid;
+                        TID_INT tid_int;
                         char c;
 
-                        if (sscanf( argv[ iarg ], SCN_TIDPAT "%c", &tid, &c ) == 1)
-                            return CancelRexxExec( tid ) ? 0 : -1;
+                        if (sscanf( argv[ iarg ], SCN_TIDPAT "%c", &tid_int, &c ) == 1)
+                            return CancelRexxExec( (TID)tid_int ) ? 0 : -1;
 
                         // "REXX(%s) Option %s value '%s' is invalid"
                         WRMSG( HHC17509, "E", PackageName,

--- a/hostopts.h
+++ b/hostopts.h
@@ -307,7 +307,7 @@
 #define HOW_TO_IMPLEMENT_SH_COMMAND       USE_ANSI_SYSTEM_API_FOR_SH_COMMAND
 #define SET_CONSOLE_CURSOR_SHAPE_METHOD   CURSOR_SHAPE_NOT_SUPPORTED
 #undef  OPTION_EXTCURS                  /* Normal cursor handling    */
-#undef  SCANDIR_CONST_STRUCT_DIRENT     /* define if scandir uses
+#define SCANDIR_CONST_STRUCT_DIRENT     /* define if scandir uses
                                            const for struct dirent   */
 
 

--- a/hthreads.c
+++ b/hthreads.c
@@ -1284,6 +1284,7 @@ DLL_EXPORT int locks_cmd( int argc, char* argv[], char* cmdline )
     TID         tid = 0;            /* Requested thread id           */
     int         i, k, rc = 0;       /* Work vars and return code     */
     char        c;                  /* sscanf work; work flag        */
+    TID_INT     tid_int;
 
     UNREFERENCED( cmdline );
 
@@ -1292,8 +1293,10 @@ DLL_EXPORT int locks_cmd( int argc, char* argv[], char* cmdline )
          if (argc <= 1)               tid = (TID)  0;
     else if (CMD( argv[1], ALL,  3 )) tid = (TID)  0;
     else if (CMD( argv[1], HELD, 4 )) tid = (TID) -1;
-    else if (sscanf( argv[1], SCN_TIDPAT "%c", &tid, &c ) != 1)
+    else if (sscanf( argv[1], SCN_TIDPAT "%c", &tid_int, &c ) != 1) {
+        tid = (TID)tid_int;
         rc = -1;
+    }
 
     if (!rc)
     {
@@ -1550,6 +1553,7 @@ DLL_EXPORT int threads_cmd( int argc, char* argv[], char* cmdline )
     char         tod[27];           /* "YYYY-MM-DD HH:MM:SS.uuuuuu"  */
     char         ht_ob_time[27];    /* "YYYY-MM-DD HH:MM:SS.uuuuuu"  */
     TID          tid = 0;           /* Requested thread id           */
+    TID_INT      tid_int;
     int          i, k, rc = 0;      /* Work vars and return code     */
     char         c;                 /* sscanf work; work flag        */
 
@@ -1560,8 +1564,10 @@ DLL_EXPORT int threads_cmd( int argc, char* argv[], char* cmdline )
          if (argc <= 1)                  tid = (TID)  0;
     else if (CMD( argv[1], ALL,     3 )) tid = (TID)  0;
     else if (CMD( argv[1], WAITING, 7 )) tid = (TID) -1;
-    else if (sscanf( argv[1], SCN_TIDPAT "%c", &tid, &c ) != 1)
+    else if (sscanf( argv[1], SCN_TIDPAT "%c", &tid_int, &c ) != 1) {
+        tid = (TID)tid_int;
         rc = -1;
+    }
 
     if (!rc)
     {

--- a/impl.c
+++ b/impl.c
@@ -793,9 +793,9 @@ static void arghelp()
 
 /* Functions in module skey.h/.c, needed by impl.c */
 
-extern inline BYTE s370_get_storage_key( U64 abs );
-extern inline BYTE s390_get_storage_key( U64 abs );
-extern inline BYTE z900_get_storage_key( U64 abs );
+extern BYTE s370_get_storage_key( U64 abs );
+extern BYTE s390_get_storage_key( U64 abs );
+extern BYTE z900_get_storage_key( U64 abs );
 
 /*-------------------------------------------------------------------*/
 /* IMPL main entry point                                             */

--- a/msgenu.h
+++ b/msgenu.h
@@ -293,7 +293,7 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp, bool quiet )
 #define HHC00108 "Ending thread "TIDPAT" %s, pri=%d, started=%d, max=%d exceeded"
 #define HHC00109 "set_thread_priority( %d ) failed: %s"
 #define HHC00110 "Defaulting all threads to priority %d"
-#define HHC00111 "Thread CPU Time IS available (_POSIX_THREAD_CPUTIME=%d)"
+#define HHC00111 "Thread CPU Time IS available (_POSIX_THREAD_CPUTIME=%ld)"
 #define HHC00112 "Thread CPU Time is NOT available."
 //efine HHC00113 - HHC00129 (available)
 

--- a/printfmt.h
+++ b/printfmt.h
@@ -114,16 +114,17 @@
 #if defined( _MSVC_ )
   #define TIDPAT             "%8.8"PRIx32       // complete format spec
   #define SCN_TIDPAT            "%"PRIx32       // complete format spec
-  #define TID_CAST( _tid )   ((U32)(_tid))      // cast to printable
+  #define TID_INT                     U32       // integer most like a TID
 #elif defined( SIZEOF_PTHREAD_T ) && SIZEOF_PTHREAD_T >= 8
   #define TIDPAT           "%16.16"PRIx64       // complete format spec
   #define SCN_TIDPAT            "%"PRIx64       // complete format spec
-  #define TID_CAST( _tid )   ((U64)(_tid))      // cast to printable
+  #define TID_INT                     U64       // integer most like a TID
 #else
   #define TIDPAT             "%8.8"PRIx32       // complete format spec
   #define SCN_TIDPAT            "%"PRIx32       // complete format spec
-  #define TID_CAST( _tid )   ((U32)(_tid))      // cast to printable
+  #define TID_INT                     U32       // integer most like a TID
 #endif
+#define TID_CAST( _tid )   ((TID_INT)(_tid))    // cast to printable
 
 #define LOG_TID_BEGIN( _tid, _name ) \
     WRMSG( HHC00100, "I", \

--- a/tcpnje.c
+++ b/tcpnje.c
@@ -1456,8 +1456,9 @@ static void *tcpnje_thread(void *vtn)
     init_signaled = 0;
 
     DBGMSG(1, "HHCTN002I %4.4X:TCPNJE - networking thread "TIDPAT" started for link %s - %s\n",
-            devnum, thread_id(), guest_to_host_string(lnodestring, sizeof(lnodestring), tn->lnode),
-                                 guest_to_host_string(rnodestring, sizeof(rnodestring), tn->rnode));
+            devnum, TID_CAST(thread_id()),
+            guest_to_host_string(lnodestring, sizeof(lnodestring), tn->lnode),
+            guest_to_host_string(rnodestring, sizeof(rnodestring), tn->rnode));
 
     if (!init_signaled)
     {

--- a/tcpnje.c
+++ b/tcpnje.c
@@ -1846,7 +1846,7 @@ static void *tcpnje_thread(void *vtn)
         if (selectcount == 0)
         {
             DBGMSG(512, "HHCTN127D %4.4X:TCPNJE - select() timeout after %ld seconds %ld microseconds\n",
-                        devnum, tvcopy.tv_sec, tvcopy.tv_usec);
+                        devnum, tvcopy.tv_sec, (long int)tvcopy.tv_usec);
 
             /* Reset Call issued flag */
             tn->callissued = 0;

--- a/tfprint.c
+++ b/tfprint.c
@@ -1729,7 +1729,7 @@ static inline void print_op_stor( const char* pfx, BYTE arch_mode, BYTE real_mod
         RTRIM(   pfx_and_vadr );        // (vadr likely empty)
         STRLCAT( pfx_and_vadr, " " );   // (blank is expected)
 
-        FLOGMSG( stdout, "%sTranslation exception %04.4"PRIX16" (%s)\n",
+        FLOGMSG( stdout, "%sTranslation exception %04"PRIX16" (%s)\n",
             pfx_and_vadr, op->xcode, PIC2Name( op->xcode ));
     }
     else
@@ -1750,10 +1750,10 @@ static inline void print_op_stor( const char* pfx, BYTE arch_mode, BYTE real_mod
         // (more efficient to print everything than to loop)
         MSGBUF( hbuf,
 
-            "%02.2X%02.2X%02.2X%02.2X "
-            "%02.2X%02.2X%02.2X%02.2X "
-            "%02.2X%02.2X%02.2X%02.2X "
-            "%02.2X%02.2X%02.2X%02.2X",
+            "%02X%02X%02X%02X "
+            "%02X%02X%02X%02X "
+            "%02X%02X%02X%02X "
+            "%02X%02X%02X%02X",
 
             op->stor[ 0], op->stor[ 1], op->stor[ 2], op->stor[ 3],
             op->stor[ 4], op->stor[ 5], op->stor[ 6], op->stor[ 7],
@@ -1779,12 +1779,12 @@ static inline void print_op_stor( const char* pfx, BYTE arch_mode, BYTE real_mod
         /* And finally print all pieces together as one line */
         if (ARCH_900_IDX == arch_mode)
         {
-            FLOGMSG( stdout, "%s%sR:%16.16"PRIX64":K:%02.2X=%s\n",
+            FLOGMSG( stdout, "%s%sR:%016"PRIX64":K:%02X=%s\n",
                 pfx, vadr, op->raddr, op->skey, stor );
         }
         else
         {
-            FLOGMSG( stdout, "%s%sR:%8.8"PRIX32":K:%02.2X=%s\n",
+            FLOGMSG( stdout, "%s%sR:%08"PRIX32":K:%02X=%s\n",
                 pfx, vadr, (U32)op->raddr, op->skey, stor );
         }
     }
@@ -1865,7 +1865,7 @@ static inline void print_814_sigp( TF00814* rec )
         MSGBUF( prm, "%8.8"PRIX32, (U32) rec->parm );
 
     // "Processor %s: CC %d%s"
-    MSGBUF( pfx, "%s HHC00814I Processor %s: SIGP %-32s (%02.2X) %s, PARM %s: CC %d",
+    MSGBUF( pfx, "%s HHC00814I Processor %s: SIGP %-32s (%02X) %s, PARM %s: CC %d",
         &tim[ 11 ], ptyp_str( rec->rhdr.cpuad ),
         order2name( rec->order ), rec->order,
         ptyp_str( rec->cpad ), prm, rec->cc );
@@ -1875,7 +1875,7 @@ static inline void print_814_sigp( TF00814* rec )
     if (rec->got_status)
         FLOGMSG( stdout, "%s\n", pfx );
     else
-        FLOGMSG( stdout, "%s status %8.8X\n", pfx, rec->status );
+        FLOGMSG( stdout, "%s status %08X\n", pfx, rec->status );
 }
 
 /******************************************************************************/


### PR DESCRIPTION
I put every type of warning in a different commit, together with the actual warning message, so it should be clear what is what, and it can be cherry-picked if desired.
With these patches, there are no compiler warnings any more on my system (except the getrusage one from #573).
(There are some linker warnings about "/usr/bin/ld: /usr/lib/libc.so and /usr/lib/crt0.o: warning: multiple common of environ" but I suspect that may be too NetBSD specific, and in any case I didn't look into it yet) 