### PR TITLE
Fix 3705 crash on attach/detach/attach.

### DIFF
--- a/comm3705.c
+++ b/comm3705.c
@@ -1470,6 +1470,8 @@ static int commadpt_init_handler (DEVBLK *dev, int argc, char *argv[])
     }
     dev->commadpt->have_cthread=1;
 
+    /* Indicate things need to be closed */
+    dev->fd = 3705;     // too high an FD to be normally used
     /* Release the CA lock */
     release_lock(&dev->commadpt->lock);
     /* Indicate succesfull completion */


### PR DESCRIPTION
If a 3705 device is attached, detached, and attached again, Hercules crashes to desktop.

Reproduce:
```
attach 590 3705 lport=3705
detach 590
attach 590 3705 lport=3705
```

The DEVBLK was never being marked as in use and needing closing. Code did reset the dev->fd to -1 to indicate it was no longer in use, and checked it, but never actually set it. Since the fd isn't used for anything but this purpose, it'ss et to a nonsense positive value.