### PR TITLE
ICOUNT changes to accomodate E7xx family, PRINT_INST & qsort

### DIFF
--- a/hstructs.h
+++ b/hstructs.h
@@ -1109,6 +1109,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
         U64 imape3[256];
         U64 imape4[256];
         U64 imape5[256];
+        U64 imape7[256];
         U64 imapeb[256];
         U64 imapec[256];
         U64 imaped[256];
@@ -1130,6 +1131,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
         U64 imape3T[256];
         U64 imape4T[256];
         U64 imape5T[256];
+        U64 imape7T[256];
         U64 imapebT[256];
         U64 imapecT[256];
         U64 imapedT[256];

--- a/opcode.h
+++ b/opcode.h
@@ -283,6 +283,9 @@ OPCD_DLL_IMPORT int iprint_router_func( int arch_mode, BYTE inst[], char mnemoni
             case 0xE5:                                              \
                 used = sysblk.imape5[(_inst)[1]]++;                 \
                 break;                                              \
+            case 0xE7:                                              \
+                used = sysblk.imape7[(_inst)[1]]++;                 \
+                break;                                              \
             case 0xEB:                                              \
                 used = sysblk.imapeb[(_inst)[5]]++;                 \
                 break;                                              \


### PR DESCRIPTION
In preparation for possible changes that may become necessary for the vector facility (129) and as a practical exercise of how pulls requests work in this project, I request these changes in the behavior of icount:

1. Counters & times tables in hstructs.h & opcode.h for E7xx instruction family. 

2. Add PRINT_INST to ouput line
```
hscemode.c(2865)  HHC02292I Sorted icount display: 
hscemode.c(2912)  HHC02292I Inst 'E371' count            2 (28%) time          617 (308.500000) LAY   0,0(0,0)               load_address_y  
hscemode.c(2912)  HHC02292I Inst 'A704' count            1 (14%) time            5 (  5.000000) BRC   0,*+0                  branch_relative_on_condition                   
hscemode.c(2912)  HHC02292I Inst '05'   count            1 (14%) time          724 (724.000000) BALR  0,0                    branch_and_link_register                       
hscemode.c(2912)  HHC02292I Inst 'E706' count            1 (14%) time            0 (  0.000000) ????? ,                      ?                                              
hscemode.c(2912)  HHC02292I Inst 'EB2F' count            1 (14%) time          347 (347.000000) LCTLG 0,0,0(0)               load_control_long                              
hscemode.c(2912)  HHC02292I Inst '00'   count            1 (14%) time            0 (  0.000000) ????? ,                      ?                                              
cmdtab.c(455)     HHC90000D DBG: RC = 0                                                               
```

3.- Change arrays to struct ICOUNT_INSTR and iterative sort to a cleanest qsort.

p.d. It's my first pull request. Please, be patient.