### PR TITLE
ICOUNT changes to accomodate E7xx family, PRINT_INST & qsort

### DIFF
--- a/hscemode.c
+++ b/hscemode.c
@@ -2855,7 +2855,7 @@ int icount_cmd( int argc, char* argv[], char* cmdline )
     }
 
     /* (sort...) */
-    qsort(icount, i, sizeof(ICOUNT_INSTR), icount_cmd_sort);				
+    qsort(icount, i, sizeof(ICOUNT_INSTR), icount_cmd_sort);
 
 #define  ICOUNT_WIDTH  "12"     /* Print field width */
 
@@ -2864,43 +2864,43 @@ int icount_cmd( int argc, char* argv[], char* cmdline )
     // "%s"
     WRMSG( HHC02292, "I", "Sorted icount display:" );
 
-	for (i1 = 0; i1 < i; i1++)
-	{
-		memset(fakeinst, 0, sizeof(fakeinst));
-		int bufl = 0;
-		switch (icount[i1].opcode1)
-		{
-		case 0x01:
-		case 0xA4:
-		case 0xA5:
-		case 0xA6:
-		case 0xA7:
-		case 0xB2:
-		case 0xB3:
-		case 0xB9:
-		case 0xC0:
-		case 0xC2:
-		case 0xC4:
-		case 0xC6:
-		case 0xC8:
-		case 0xE3:
-		case 0xE4:
-		case 0xE5:
-		case 0xE7:
-		case 0xEB:
-		case 0xEC:
-		case 0xED:
-		{
+   for (i1 = 0; i1 < i; i1++)
+   {
+      memset(fakeinst, 0, sizeof(fakeinst));
+      int bufl = 0;
+      switch (icount[i1].opcode1)
+      {
+      case 0x01:
+      case 0xA4:
+      case 0xA5:
+      case 0xA6:
+      case 0xA7:
+      case 0xB2:
+      case 0xB3:
+      case 0xB9:
+      case 0xC0:
+      case 0xC2:
+      case 0xC4:
+      case 0xC6:
+      case 0xC8:
+      case 0xE3:
+      case 0xE4:
+      case 0xE5:
+      case 0xE7:
+      case 0xEB:
+      case 0xEC:
+      case 0xED:
+      {
             MSGBUF(instText, "'%2.2X%2.2X'", icount[i1].opcode1, icount[i1].opcode2);
             fakeinst[icount[i1].opc2pos] = icount[i1].opcode2;
-			break;
-		}
-		default:
-		{
+         break;
+      }
+        default:
+      {
             MSGBUF(instText, "'%2.2X'  ", icount[i1].opcode1);
-			break;
-		}
-		}
+            break;
+        }
+      }
         bufl = MSGBUF
         (
             buf, "Inst %s count %" ICOUNT_WIDTH PRIu64 " (%2d%%) time %" ICOUNT_WIDTH PRIu64 " (%10f) ",
@@ -2908,9 +2908,9 @@ int icount_cmd( int argc, char* argv[], char* cmdline )
             icount[i1].time, ((float)icount[i1].time / icount[i1].count)
         );
         fakeinst[0] = icount[i1].opcode1;
-		bufl += PRINT_INST(regs->arch_mode, fakeinst, buf + bufl);
-		WRMSG(HHC02292, "I", buf);
-	}
+      bufl += PRINT_INST(regs->arch_mode, fakeinst, buf + bufl);
+      WRMSG(HHC02292, "I", buf);
+   }
 
     return 0;
 }

--- a/hstructs.h
+++ b/hstructs.h
@@ -1109,6 +1109,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
         U64 imape3[256];
         U64 imape4[256];
         U64 imape5[256];
+        U64 imape7[256];
         U64 imapeb[256];
         U64 imapec[256];
         U64 imaped[256];
@@ -1130,6 +1131,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
         U64 imape3T[256];
         U64 imape4T[256];
         U64 imape5T[256];
+        U64 imape7T[256];
         U64 imapebT[256];
         U64 imapecT[256];
         U64 imapedT[256];
@@ -1152,6 +1154,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
             + sizeof(sysblk.imape3) \
             + sizeof(sysblk.imape4) \
             + sizeof(sysblk.imape5) \
+            + sizeof(sysblk.imape7) \
             + sizeof(sysblk.imapeb) \
             + sizeof(sysblk.imapec) \
             + sizeof(sysblk.imaped) \
@@ -1172,6 +1175,7 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
             + sizeof(sysblk.imape3T) \
             + sizeof(sysblk.imape4T) \
             + sizeof(sysblk.imape5T) \
+            + sizeof(sysblk.imape7T) \
             + sizeof(sysblk.imapebT) \
             + sizeof(sysblk.imapecT) \
             + sizeof(sysblk.imapedT) \

--- a/opcode.h
+++ b/opcode.h
@@ -283,6 +283,9 @@ OPCD_DLL_IMPORT int iprint_router_func( int arch_mode, BYTE inst[], char mnemoni
             case 0xE5:                                              \
                 used = sysblk.imape5[(_inst)[1]]++;                 \
                 break;                                              \
+            case 0xE7:                                              \
+                used = sysblk.imape7[(_inst)[5]]++;                 \
+                break;                                              \
             case 0xEB:                                              \
                 used = sysblk.imapeb[(_inst)[5]]++;                 \
                 break;                                              \
@@ -374,6 +377,9 @@ OPCD_DLL_IMPORT int iprint_router_func( int arch_mode, BYTE inst[], char mnemoni
                 break;                                              \
             case 0xE5:                                              \
                 sysblk.imape5T[(_inst)[1]]+=elapsed_usecs;          \
+                break;                                              \
+            case 0xE7:                                              \
+                sysblk.imape7T[(_inst)[5]]+=elapsed_usecs;          \
                 break;                                              \
             case 0xEB:                                              \
                 sysblk.imapebT[(_inst)[5]]+=elapsed_usecs;          \


### PR DESCRIPTION
In preparation for possible changes that may become necessary for the vector facility (129) and as a practical exercise of how pulls requests work in this project, I request these changes in the behavior of icount:

1.- Counters & times tables in hstructs.h & opcode.h for E7xx instruction family.

2.- Add PRINT_INST to ouput line

```
hscemode.c(2865)  HHC02292I Sorted icount display: 
hscemode.c(2912)  HHC02292I Inst 'E371' count            2 (28%) time          617 (308.500000) LAY   0,0(0,0)               load_address_y  
hscemode.c(2912)  HHC02292I Inst 'A704' count            1 (14%) time            5 (  5.000000) BRC   0,*+0                  branch_relative_on_condition                   
hscemode.c(2912)  HHC02292I Inst '05'   count            1 (14%) time          724 (724.000000) BALR  0,0                    branch_and_link_register                       
hscemode.c(2912)  HHC02292I Inst 'E706' count            1 (14%) time            0 (  0.000000) ????? ,                      ?                                              
hscemode.c(2912)  HHC02292I Inst 'EB2F' count            1 (14%) time          347 (347.000000) LCTLG 0,0,0(0)               load_control_long                              
hscemode.c(2912)  HHC02292I Inst '00'   count            1 (14%) time            0 (  0.000000) ????? ,                      ?                                              
cmdtab.c(455)     HHC90000D DBG: RC = 0                                                               

```
3.- Change arrays to struct ICOUNT_INSTR and iterative sort to a cleanest qsort.

p.d. This is my first pull request. Please, be patient.