### PR TITLE
Terminal session output during shutdown (Issue 645)

### DIFF
--- a/hscmisc.c
+++ b/hscmisc.c
@@ -1473,6 +1473,7 @@ static void do_shutdown_now()
 {
     int     spincount = 16;           // spin-wait count for logger-thread
     bool    loggersetshutdown = TRUE; // assume logger sets system shutdown
+    bool    wasPanelActive = TRUE;    // panel state
 
     ASSERT( !sysblk.shutfini );   // (sanity check)
     ASSERT( !sysblk.shutdown );   // (sanity check)
@@ -1483,15 +1484,31 @@ static void do_shutdown_now()
     // "Begin Hercules shutdown"
     WRMSG( HHC01420, "I" );
 
-    // (hack to prevent minor message glitch during shutdown)
-    fflush( stdout );
-    fflush( stderr );
+    // spin-wait for panel to do its cleanup
+    wasPanelActive = (bool) sysblk.panel_init;
+    spincount = 32;
+    while ( sysblk.panel_init && spincount-- )
+    {
+        log_wakeup( NULL );
+        USLEEP( (sysblk.panrate * 1000)  / 8);
+        //LOGMSG("hsmisc.c: shutdown spin-wait on panel count: %d, sysblk.panel_init: %d\n", spincount, (int) sysblk.panel_init);
+    }
+
+    // was panel thread active and has complete cleanup
+    if ( wasPanelActive && !sysblk.panel_init )
+    {
+        // Programmer note: If the panel was active and has completed cleanup,
+        // a message needs to be issued in order to pump a logger processing cycle
+        // to recognize shutdown has started.
+        WRMSG( HHC01421, "I" , "Panel cleanup complete");
+    }
 
     // spin-wait for logger to initiate system shutdown
+    spincount = 16;
     while ( !sysblk.shutdown && spincount-- )
     {
         log_wakeup( NULL );
-        USLEEP( 5000 );
+        USLEEP( (5000) );
         //LOGMSG("hsmisc.c: shutdown spin-wait on logger: count: %d, shutdown: %d\n", spincount, (int) sysblk.shutdown);
     }
 
@@ -1500,6 +1517,7 @@ static void do_shutdown_now()
     {
         sysblk.shutdown = TRUE;       // (system shutdown initiated)
         loggersetshutdown = FALSE;    // logger didn't set system shutdown
+        WRMSG( HHC01421, "E" , "Failsafe shutdown actioned");
     }
 
     /* Wakeup I/O subsystem to start I/O subsystem shutdown */
@@ -1514,11 +1532,6 @@ static void do_shutdown_now()
 
     // "Calling termination routines"
     WRMSG( HHC01423, "I" );
-
-    // (hack to prevent minor message glitch during shutdown)
-    fflush( stdout );
-    fflush( stderr );
-    USLEEP( 10000 );
 
     // if logger didn't set shutdown, handle unredirect
     if ( !loggersetshutdown )

--- a/hscmisc.c
+++ b/hscmisc.c
@@ -1479,13 +1479,16 @@ static void do_shutdown_now()
     ASSERT( !sysblk.shutdown );   // (sanity check)
     sysblk.shutfini = FALSE;      // (shutdown NOT finished yet)
     sysblk.shutdown = FALSE;      // (system shutdown NOT initiated yet)
-    sysblk.shutbegin = TRUE;      // (begin system shutdown)
+
+    // save panel state and start shutdown
+    wasPanelActive = (bool) sysblk.panel_init;
+    sysblk.shutbegin = TRUE;
 
     // "Begin Hercules shutdown"
     WRMSG( HHC01420, "I" );
 
     // spin-wait for panel to do its cleanup
-    wasPanelActive = (bool) sysblk.panel_init;
+
     spincount = 32;
     while ( sysblk.panel_init && spincount-- )
     {

--- a/logger.c
+++ b/logger.c
@@ -461,7 +461,7 @@ static void* logger_thread( void* arg )
            - handle all logger pre-shutdown actions
            - set system shutdown flag
         */
-        if (sysblk.shutbegin)
+        if (sysblk.shutbegin & !sysblk.panel_init)
         {
             obtain_lock( &logger_lock );
             {

--- a/msgenu.h
+++ b/msgenu.h
@@ -1100,7 +1100,7 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp, bool quiet )
 #define HHC01418 "Symbol expansion will result in buffer overflow; ignored"
 #define HHC01419 "Symbol and/or Value is invalid; ignored"
 #define HHC01420 "Begin Hercules shutdown"
-//efine HHC01421 (available)
+#define HHC01421 "Shutdown: %s"
 #define HHC01422 "Configuration released"
 #define HHC01423 "Calling termination routines"
 #define HHC01424 "All termination routines complete"


### PR DESCRIPTION
Fish,

The request handles two items:

1. replaces clean_screen() in panel_cleanup with blank_panel() to fix Issue 645.
2. adds some synchronization, controlled by hsmisc.c, between logger and panel. This synchronization improves terminal console message capture at shutdown. A new message 'HHC01421I Shutdown: %s' has been added.

Sorry, I should have separated this into two commits. 

I've tested the request on my Linux system and on Windows (only very basic tests). On my Linux system with Regina Rexx, 'make check' completes.

Again, the request need your review, and maybe some testing by Bill on other OS's.

Jim

  