### PR TITLE
Add missing includes to configure script

### DIFF
--- a/autoconf/hercules.m4
+++ b/autoconf/hercules.m4
@@ -380,6 +380,7 @@ AC_DEFUN([HC_CHECK_NEED_GETOPT_OPTRESET],
             AC_TRY_LINK(
                 [],
                 [
+                    #include <unistd.h>
                     extern int optreset;
                     optreset=1;
                     getopt(0,0,0);

--- a/configure.ac
+++ b/configure.ac
@@ -1872,6 +1872,8 @@ if test "$GCC" = "yes"; then
                             -g -O2 -fomit-frame-pointer
                     */
 
+                    #include <string.h>
+
                     int foo ()
                     {
                         char a[50000+16];


### PR DESCRIPTION
This is needed for gcc 14 and clang 16 as they both make implicit function definitions a hard error.  In a configure script, this means these tests will switch from passing to failing, which likely means features will get unintentionally flipped as configure now thinks you don't have support.

See: https://wiki.gentoo.org/wiki/Modern_C_porting
See: https://bugs.gentoo.org/931607