### PR TITLE
Zvector E6 instruction updates

### DIFF
--- a/opcode.c
+++ b/opcode.c
@@ -3431,7 +3431,7 @@ IPRINT_FUNC(ASMFMT_VRX);
 IPRINT_FUNC(ASMFMT_VSI);
     int v1, d2, b2, i3;
     UNREFERENCED(regs);
-    v1 = ((inst[4] >> 4) & 0x0F) | ((inst[4] & 0x08) << 1);
+    v1 = ((inst[4] >> 4) & 0x0F) | ((inst[4] & 0x01) << 4);
     d2 = (inst[2] & 0x0F) << 8 | inst[3];
     b2 = inst[2] >> 4;
     i3 = inst[1];

--- a/zvector.c
+++ b/zvector.c
@@ -9,6 +9,16 @@
 /* Interpretive Execution - (C) Copyright Jan Jaeger, 1999-2012      */
 /* z/Architecture support - (C) Copyright Jan Jaeger, 1999-2012      */
 
+/* ============================================= */
+/* TEMPORARY while zvector2.c is being developed */
+#if defined(__GNUC__)
+    #pragma GCC diagnostic ignored "-Wunused-variable"
+    #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+    #pragma GCC diagnostic ignored "-Wcomment"
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+/* ============================================= */
+
 #include "hstdinc.h"
 #define _ZVECTOR_C_
 #define _HENGINE_DLL_

--- a/zvector.c
+++ b/zvector.c
@@ -9,16 +9,6 @@
 /* Interpretive Execution - (C) Copyright Jan Jaeger, 1999-2012      */
 /* z/Architecture support - (C) Copyright Jan Jaeger, 1999-2012      */
 
-/* ============================================= */
-/* TEMPORARY while zvector2.c is being developed */
-#if defined(__GNUC__)
-    #pragma GCC diagnostic ignored "-Wunused-variable"
-    #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-    #pragma GCC diagnostic ignored "-Wcomment"
-    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-/* ============================================= */
-
 #include "hstdinc.h"
 #define _ZVECTOR_C_
 #define _HENGINE_DLL_

--- a/zvector2.c
+++ b/zvector2.c
@@ -1917,7 +1917,7 @@ DEF_INST( vector_convert_to_decimal_32 )
     {
         /* signed */
         tempS32 = (S32) reg32;
-        if ( reg32.sreg >= 0 )
+        if ( tempS32 >= 0 )
         {
             possign = true;
             convert = (U32) tempS32;
@@ -1925,7 +1925,7 @@ DEF_INST( vector_convert_to_decimal_32 )
         else
         {
             possign = false;
-            convert = - (U32) -tempS32 ;
+            convert = (U32) -tempS32 ;
         }
     }
 

--- a/zvector2.c
+++ b/zvector2.c
@@ -2386,19 +2386,19 @@ DEF_INST( vector_perform_sign_operation_decimal )
         {
             if (isZero)
             {
-                   if ( !pc && !nz )
+                if ( !pc && !nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_PLUS);  break;  }
 
-                   if ( pc && !nz )
+                if ( pc && !nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_ZONE);  break;  }
 
-                   if ( nz )
+                if ( nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
 
             }
             else
             {
-                    { cc = 1; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
+                { cc = 1; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
             }
         }
         break;

--- a/zvector2.c
+++ b/zvector2.c
@@ -2386,19 +2386,19 @@ DEF_INST( vector_perform_sign_operation_decimal )
         {
             if (isZero)
             {
-                if ( !pc && !nz )
+                   if ( !pc && !nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_PLUS);  break;  }
 
-                if ( pc && !nz )
+                   if ( pc && !nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_ZONE);  break;  }
 
-                if ( nz )
+                   if ( nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
 
             }
             else
             {
-                { cc = 1; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
+                    { cc = 1; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
             }
         }
         break;

--- a/zvector2.c
+++ b/zvector2.c
@@ -2291,8 +2291,6 @@ DEF_INST( vector_perform_sign_operation_decimal )
     {
         case 0x00:                     /* 00 (maintain)       */
         {
-            if ( !LV_HAS_VALID_SIGN( LV2 ) )   { cc = 2; break;  }
-
             if (isZero)
             {
                if ( LV_HAS_PLUS_SIGN( LV2 ) && pc )
@@ -2309,6 +2307,9 @@ DEF_INST( vector_perform_sign_operation_decimal )
 
                 if ( LV_HAS_MINUS_SIGN( LV2 ) && nz )
                     { cc = 0; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
+
+                if ( !LV_HAS_VALID_SIGN( LV2 ) )
+                    { cc = 0; break;  }
             }
             else
             {
@@ -2318,8 +2319,11 @@ DEF_INST( vector_perform_sign_operation_decimal )
                 if ( LV_HAS_PLUS_SIGN( LV2 ) && !pc )
                     { cc = 2; SET_VR_SIGN( v1, PREFERRED_PLUS);  break;  }
 
-                if ( LV_HAS_MINUS_SIGN( LV2 ) && nz )
+                if ( LV_HAS_MINUS_SIGN( LV2 ) )
                     { cc = 1; SET_VR_SIGN( v1, PREFERRED_MINUS);  break;  }
+
+                if ( !LV_HAS_VALID_SIGN( LV2 ) )
+                    { cc = 2; break;  }
             }
         }
         break;


### PR DESCRIPTION
Fish,

As I've been working on instruction tests for z/vector E6 instructions, I've discovered a few errors. So, this request has a number of updates to E6 instructions. 

[salva-rczero](https://github.com/salva-rczero) Thanks again for spotting the issue with IPRINT_FUNC(ASMFMT_VSI). I've included your change.
 
Thanks,
Jim