### PR TITLE
autoconf/hercules.m4: fix compiling error w/ modern C duing configure

### DIFF
--- a/autoconf/hercules.m4
+++ b/autoconf/hercules.m4
@@ -284,6 +284,7 @@ AC_DEFUN([_HC_CHECK_NEED_GETOPT_WRAPPER],
                    Will the linker complain about duplicate
                    symbols for getopt? We'll soon find out!
                 */
+                extern int getopt(int, char *const[], const char *);
                 extern char *optarg;
                 extern int optind;
 
@@ -308,6 +309,8 @@ DUPGETOPT1
                    needs getopt. Will linker complain about
                    duplicate symbols for getopt? Let's see.
                 */
+                extern int getopt(int, char *const[], const char *);
+                extern int test1();
                 extern char *optarg;
                 extern int optind;
                 extern int test2();
@@ -327,11 +330,11 @@ DUPGETOPT1
                 }
 DUPGETOPT2
 
-            libtool --mode=compile ${CC-cc} conftest1.c -c -o conftest1.lo > /dev/null 2>&1
-            libtool --mode=compile ${CC-cc} conftest2.c -c -o conftest2.lo > /dev/null 2>&1
+            libtool --tag=CC --mode=compile ${CC-cc} conftest1.c -c -o conftest1.lo > /dev/null 2>&1
+            libtool --tag=CC --mode=compile ${CC-cc} conftest2.c -c -o conftest2.lo > /dev/null 2>&1
 
-            libtool --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest1.lo                 -o libconftest1.la > /dev/null 2>&1
-            libtool --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest2.lo libconftest1.la -o libconftest2.la > /dev/null 2>&1
+            libtool --tag=CC --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest1.lo                 -o libconftest1.la > /dev/null 2>&1
+            libtool --tag=CC --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest2.lo libconftest1.la -o libconftest2.la > /dev/null 2>&1
 
             if test $? = 0; then
 


### PR DESCRIPTION
1. withoug "--tag", libtool will:
     libtool:   error: specify a tag with '--tag'
     libtool: compile: unable to infer tagged configuration
2. without "extern ...", compile will:
     error: implicit declaration of function 'getopt'
     error: implicit declaration of function 'test1'

both will cause false postive of feature test, i.e.,
"checking whether getopt wrapper kludge is necessary" report yes always
then config.h always has "#define NEED_GETOPT_WRAPPER 1".


In fact, redirect all output to /dev/null hide many information (some are unexpected in any case).