### PR TITLE
Remove possible requirement for a ctrl-d to finish a 'Make Check'

### DIFF
--- a/impl.c
+++ b/impl.c
@@ -1747,7 +1747,11 @@ int     rc, maxprio, minprio;
         {
             /* daemon mode without any external GUI... */
 
-            process_script_file( "-", true );
+            /* If this is NOT a Test, process stdin */
+            if (!sysblk.scrtest)
+            {
+                process_script_file( "-", true );
+            }
 
             /* We come here only if the user did ctl-d on a tty,
                or we reached EOF on stdin.  No quit command has


### PR DESCRIPTION
As per Hercules-Helper, 'make check' 
```
Be patient, this can take a while with no output.

If you check top/htop and nothing seems to be happening, 
try hitting Return or CTRL+D.
```
I frequently use 'make check'. On my Raspberry PI 5 with Ubuntu 24.04, I always have to remember a ctrl-d.  It's finally becoming annoying. So, I am proposing this change. 

But, as I know nothing about, or how people may using, 'daemon mode without any external GUI...', I'm looking for comments/further review.

Thanks,
Jim  

  