### PR TITLE
Fix #717

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -253,11 +253,11 @@
 
   call   :tempfn                            calc_mttof_rexx    .rexx
 
-  echo   PARSE ARG '"' formula '"'     >   %calc_mttof_rexx%
-  echo   INTERPRET 'mttof = 'formula   >>  %calc_mttof_rexx%
-  echo   SAY FORMAT(mttof,,1)          >>  %calc_mttof_rexx%
-  for    /f %%i in ('rexx.exe              %calc_mttof_rexx% "%formula%"') do set mttof=%%i
-  del                                      %calc_mttof_rexx% >nul 2>&1
+  echo   formula = STRIP(ARG(1),'B','^"') >   %calc_mttof_rexx%
+  echo   INTERPRET 'mttof = 'formula      >>  %calc_mttof_rexx%
+  echo   SAY FORMAT(mttof,,1)             >>  %calc_mttof_rexx%
+  for    /f %%i in ('rexx.exe                 %calc_mttof_rexx% "%formula%"') do set mttof=%%i
+  del                                         %calc_mttof_rexx% >nul 2>&1
 
   endlocal && set "mttof=%mttof%"
   %return%


### PR DESCRIPTION
This update changes `tests\runtest.cmd` to remove the double-quotes from `formula` if they exist, and to leave it alone if they do not.  This should work in all versions of Windows, regardless of whether it passes the double-quotes to Rexx or not.