### PR TITLE
Fix CDSG on aarch64.

### DIFF
--- a/machdep.h
+++ b/machdep.h
@@ -535,12 +535,16 @@ inline int cmpxchg16_aarch64(U64 *old1, U64 *old2, U64 new1, U64 new2, volatile 
     int result = 1;
     U64 expected1 = *old1;
     U64 expected2 = *old2;
-    __asm __volatile(
-        "ldaxp %[old1], %[old2], [%[ptr]]"
-            : [old1] "+r" (*old1), [old2] "+r" (*old2)
-            : [ptr] "r" (ptr));
-    if ( expected1 == *old1 && expected2 == *old2 )
+    while ( result )
     {
+        __asm __volatile(
+            "ldaxp %[old1], %[old2], [%[ptr]]"
+                : [old1] "+r" (*old1), [old2] "+r" (*old2)
+                : [ptr] "r" (ptr));
+        if ( expected1 != *old1 || expected2 != *old2 )
+        {
+            return 1;
+        }
         __asm __volatile(
             "stlxp %w[result], %[new1], %[new2], [%[ptr]]"
                 : [result] "+r" (result)


### PR DESCRIPTION
The CSDG instruction is defined as succeeding if the target location contains the expected value.
A LL/SC pair without a retry loop can cause a spurious failure if something (scheduler interrupt, write to an adjacent location, etc) causes the cpu to lose the exclusive access after comparison, but before the store. Notably, this causes memory corruption on linux after commit 6801be4f, which started using CDSG for SLUB freelist management. On my M1 Pro (taskset-ed to only P-cores), it results in a kernel panic either during boot, or shortly after qeth drivers get probed.