### PR TITLE
Stop log_read() returning unwritten buffer region

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -115,8 +115,16 @@ int bytes_returned;
 
         if (*msgidx >= logger_currmsg)
         {
-            bytes_returned = logger_bufsize - *msgidx;
-            *msgidx = 0;
+            if (logger_wrapped) 
+            {
+                bytes_returned = logger_bufsize - *msgidx;
+                *msgidx = 0;
+            }
+            else
+            {
+                bytes_returned = 0;
+                *msgidx = logger_currmsg;
+            }  
         }
         else
         {


### PR DESCRIPTION
In the case where the log buffer has NOT wrapped log_read() would return uninitialized data if the request index is past the current write point.