### PR TITLE
Fix format string crash: replace %n with %d in malloc error messages

### DIFF
--- a/ctc_ptp.c
+++ b/ctc_ptp.c
@@ -2502,7 +2502,7 @@ PTPHDR*  alloc_ptp_buffer( DEVBLK* pDEVBLK, int iSize )
     if (!pPTPHDR)                      // if the allocate was not successful...
     {
         // Report the bad news.
-        MSGBUF( etext, "malloc(%n)", &iBufLen );
+        MSGBUF( etext, "malloc(%d)", iBufLen );
         // HHC00900 "%1d:%04X %s: error in function %s: %s"
         WRMSG(HHC00900, "E", SSID_TO_LCSS(pDEVBLK->ssid), pDEVBLK->devnum, pDEVBLK->typname,
                              etext, strerror(errno) );
@@ -2535,7 +2535,7 @@ void*  alloc_storage( DEVBLK* pDEVBLK, int iSize )
     if (!pStorPtr)                     // if the allocate was not successful...
     {
         // Report the bad news.
-        MSGBUF( etext, "malloc(%n)", &iStorLen );
+        MSGBUF( etext, "malloc(%d)", iStorLen );
         // HHC00900 "%1d:%04X %s: error in function %s: %s"
         WRMSG(HHC00900, "E", SSID_TO_LCSS(pDEVBLK->ssid), pDEVBLK->devnum, pDEVBLK->typname,
                              etext, strerror(errno) );

--- a/qeth.c
+++ b/qeth.c
@@ -6587,7 +6587,7 @@ static OSA_BHR*  alloc_buffer( DEVBLK* dev, int size )
     if (!bhr)                              // if the allocate was not successful...
     {
         // Report the bad news.
-        MSGBUF( etext, "malloc(%n)", &buflen );
+        MSGBUF( etext, "malloc(%d)", buflen );
         // HHC00900 "%1d:%04X %s: error in function %s: %s"
         WRMSG(HHC00900, "E", LCSS_DEVNUM, dev->typname,
                              etext, strerror(errno) );


### PR DESCRIPTION
___
_**Note:** this issue is closely related to issues [\#723: "Qeth: at shutdown "buffer overflow detected""](https://github.com/SDL-Hercules-390/hyperion/issues/723) and [\#805: "Hercules crash on on TCPIP availability on z/os 3.1"](https://github.com/SDL-Hercules-390/hyperion/issues/805)._
___
## Summary

Fix `%n` format specifier misuse in `snprintf` (via `MSGBUF` macro) that causes Hercules to crash when QETH or PTP networking is used.

**Three lines changed in two files:**

| File | Line | Before | After |
|------|------|--------|-------|
| `qeth.c` | 6590 | `MSGBUF(etext, "malloc(%n)", &buflen)` | `MSGBUF(etext, "malloc(%d)", buflen)` |
| `ctc_ptp.c` | 2505 | `MSGBUF(etext, "malloc(%n)", &iBufLen)` | `MSGBUF(etext, "malloc(%d)", iBufLen)` |
| `ctc_ptp.c` | 2538 | `MSGBUF(etext, "malloc(%n)", &iStorLen)` | `MSGBUF(etext, "malloc(%d)", iStorLen)` |

## Root cause

The `%n` format specifier in `printf`/`snprintf` does **not** print a value — it **writes** the number of bytes output so far to the memory address pointed to by the corresponding argument. This is the opposite of what the code intends (which is to print the malloc size in an error message like `"malloc(4096)"`).

- **Linux/macOS**: On modern systems compiled with `_FORTIFY_SOURCE=2` (the default on Ubuntu, Fedora, macOS, etc.), glibc/libc detects `%n` inside `snprintf` as a potential format string attack and immediately aborts the process. This produces the `"buffer overflow detected: terminated"` message.
- **Windows**: The `%n` specifier is disabled by default and will invoke the Invalid Parameter Handler if used.

All three variables (`buflen`, `iBufLen`, `iStorLen`) are declared as `int`, so `%d` is the correct format specifier on all platforms.

## Impact

This bug affects anyone running Hercules with QETH or PTP networking on modern Linux, macOS, or Windows hosts. It has been reported as causing TCPIP crashes with z/OS 3.1 and z/OS 2.5 guests.

Fixes: #805
Refs: #723