### PR TITLE
Address issues #804, #814 and #815

### DIFF
--- a/cgibin.c
+++ b/cgibin.c
@@ -214,7 +214,8 @@ void cgibin_psw(WEBBLK *webblk)
     {
         hprintf(webblk->sock, "<INPUT type=submit value=\"Auto Refresh\" name=autorefresh>\n");
         hprintf(webblk->sock, "Refresh Interval: ");
-        hprintf(webblk->sock, "<INPUT type=text size=2 name=\"refresh_interval\" value=%d>\n",
+        hprintf(webblk->sock, "<INPUT type=\"text\" size=\"2\" name=\"refresh_interval\" "
+           "pattern=\"[1-9][0-9]*\" value=\"%d\" title=\"Must be an integer > 0\">\n",
            refresh_interval);
     }
     else
@@ -388,7 +389,8 @@ int     msgcount = 22;
     {
         hprintf(webblk->sock, "<INPUT type=submit value=\"Auto Refresh\" name=autorefresh>\n");
         hprintf(webblk->sock, "Refresh Interval: ");
-        hprintf(webblk->sock, "<INPUT type=text name=\"refresh_interval\" size=2 value=%d>\n",
+        hprintf(webblk->sock, "<INPUT type=text name=\"refresh_interval\" size=2 value=%d "
+                              "pattern=\"[1-9][0-9]*\" title=\"Must be an integer > 0\">\n",
            refresh_interval);
     }
     else
@@ -426,6 +428,29 @@ int     msgcount = 22;
 
     html_footer(webblk);
 
+}
+
+/*-------------------------------------------------------------------*/
+/*                        cgibin_syslog_js                           */
+/* Processes any supplied command and then use Javascript to access  */
+/* the log via the JSON API interface below.                         */
+/* NOTE: extra function as we need to leave existing syslog          */
+/*       method in place for existing users.                         */
+/*-------------------------------------------------------------------*/
+void cgibin_syslog_js(WEBBLK *webblk)
+{
+    char   *command;
+    extern void http_download();
+
+    if ((command = cgi_variable(webblk,"command")))
+    {
+        panel_command(command);
+        // Wait a bit before proceeding in case
+        // the command issues a lot of messages
+        USLEEP(50000);
+    }
+    
+    http_download(webblk, "syslog_js.html");
 }
 
 /*-------------------------------------------------------------------*/
@@ -1201,6 +1226,48 @@ void cgibin_xml_rates_info(WEBBLK *webblk)
 /*-------------------------------------------------------------------*/
 
 /*-------------------------------------------------------------------*/
+/* Helpers: properly escape a string for safe inclusion in JSON      */
+/* NOTE: char version required for when no trailing \0 - syslog !    */
+/*-------------------------------------------------------------------*/
+static void json_escape_char(int sock, char c)
+{
+    switch (c)
+    {
+        case '"':   hprintf(sock, "\\\"");  break;
+        case '\\':  hprintf(sock, "\\\\");  break;
+        case '\b':  hprintf(sock, "\\b");   break;
+        case '\f':  hprintf(sock, "\\f");   break;
+        case '\n':  hprintf(sock, "\\n");   break;
+        case '\r':  hprintf(sock, "\\r");   break;
+        case '\t':  hprintf(sock, "\\t");   break;
+        default  :
+            if (isprint(c))
+                hprintf(sock, "%c", c);
+            else
+                hprintf(sock, "\\u%04X", c);
+            break;
+    }
+}  
+
+static void json_escape_string(int sock, const char *str)
+{
+    char c;
+    
+    if (!str || !*str)
+    {
+        hprintf(sock, "\"\"");
+        return;
+    }
+
+    hprintf(sock, "\"");
+
+    while ((c = *str++))
+       json_escape_char(sock, c);
+    
+    hprintf(sock, "\"");
+}
+
+/*-------------------------------------------------------------------*/
 /*                      cgibin_api_v1                                */
 /*-------------------------------------------------------------------*/
 /* Returns a JSON file of all the available APIs:                    */
@@ -1596,6 +1663,7 @@ void cgibin_api_v1_psw(WEBBLK *webblk)
 /*     "command": "",                                                */
 /*     "msgcount": 22,                                               */
 /*     "syslog": "[<array of lines from syslog based on msgcount>]"  */
+/*     "index": index_to_last_msg                                    */
 /* }                                                                 */
 /*-------------------------------------------------------------------*/
 /* Notes:                                                            */
@@ -1605,6 +1673,9 @@ void cgibin_api_v1_psw(WEBBLK *webblk)
 /* - msgcount is a variable and can be changed via get/post/cookie   */
 /*   and controls the number of lines returned in "syslog",          */
 /*   the default is 22 lines                                         */
+/* - index is a variable and represents the byte position in the log */
+/*   buffer to request data from                                     */
+/*   NOTE: mgscount if set > 0 takes precedence over index           */
 /*-------------------------------------------------------------------*/
 void cgibin_api_v1_syslog(WEBBLK *webblk)
 {
@@ -1615,6 +1686,9 @@ void cgibin_api_v1_syslog(WEBBLK *webblk)
     char   *command;
     char   *value;
     int     msgcount = 22;
+    int     index = -1;
+    int     newline = true;
+    int     first = true;
 
     json_header( webblk );
 
@@ -1631,12 +1705,14 @@ void cgibin_api_v1_syslog(WEBBLK *webblk)
 
     if((value = cgi_variable(webblk,"msgcount")))
         msgcount = atoi(value);
+    
+    if((value = cgi_variable(webblk,"index")))
+        index = atoi(value);
 
     hprintf(webblk->sock,"\"msgcount\": %d,",msgcount);
-    hprintf(webblk->sock,"\"syslog\": [\"");
+    hprintf(webblk->sock,"\"syslog\": [");
 
-
-    logbuf_idx = msgcount ? log_line( msgcount ) : -1;
+    logbuf_idx = msgcount ? log_line( msgcount ) : index;
 
     while ((num_bytes = log_read( &logbuf_ptr, &logbuf_idx, LOG_NOBLOCK )) > 0)
     {
@@ -1646,43 +1722,46 @@ void cgibin_api_v1_syslog(WEBBLK *webblk)
         if (wrk_bufptr)
         {
             sav_wrk = wrk_bufptr;
-            strncpy( wrk_bufptr,  logbuf_ptr, num_bytes );
+            memcpy( wrk_bufptr,  logbuf_ptr, num_bytes );
         }
-        else         wrk_bufptr = logbuf_ptr;
-
+        else
+            wrk_bufptr = logbuf_ptr;
 
         // We need to escape certain characters that are
-        // not supported in JSON, namely '"', '\n' and '\'"
-
+        // not supported in JSON, namely '"', '\'", etc.
+        // A new line (\n) here means start new JSON array item
+        
         while ( num_bytes-- )
-        {
-            switch ( *wrk_bufptr )
+        {   
+            int c;
+            
+            if  ( newline )
             {
-            case '\\':
-                hwrite( webblk->sock, "\\\\"    , 2);
-                break;
-            case '\n':
-                //hwrite( webblk->sock, "\\n"    , 2                );
-        hprintf(webblk->sock,"\",\"");
-                break;
-            case '"':
-                hwrite( webblk->sock, "\\\""    , 2  );
-                break;
-            default:
-                hwrite( webblk->sock, wrk_bufptr , 1              );
-                break;
+                if ( ! first) 
+                    hwrite( webblk->sock, ",", 1);
+                else
+                    first = false;
+                hwrite( webblk->sock, "\"", 1);
+                newline = false;
             }
+            if ((c = *wrk_bufptr++) == '\n' )   // end of this line - new array element
+            {     
+                hwrite(webblk->sock,"\"", 1);
+                newline = true;
+            }
+            else
+                json_escape_char(webblk->sock, c);
 
-            wrk_bufptr++;
         }
 
         // (free our work buffer if it's really ours)
-
         if ( sav_wrk )
             free( sav_wrk );
     }
 
-    hprintf(webblk->sock,"\"]}");
+    hprintf(webblk->sock,"],");
+    hprintf(webblk->sock,"\"index\": %d",logbuf_idx);
+    hprintf(webblk->sock,"}");
 }
 
 /*-------------------------------------------------------------------*/
@@ -1804,21 +1883,25 @@ void cgibin_api_v1_devices(WEBBLK *webblk)
                 }
             }
 
-             hprintf(webblk->sock,"{\"devnum\":\"%4.4X\","
-                                   "\"subchannel\":\"%4.4X\","
-                                   "\"devclass\": \"%s\","
-                                   "\"devtype\": \"%4.4X\","
-                                   "\"status\": \"%s%s%s\","
-                                   "\"assignment\": \"%s\"}"
-                                   "%s",
-                                   dev->devnum,dev->subchan,
-                                   devclass,
-                                   dev->devtype,
-                                   (dev->fd >= 0       ? "open "    : ""),
-                                   (dev->busy          ? "busy "    : ""),
-                                   (IOPENDING(dev)     ? "pending " : ""),
-                                   devnam,
-                                   (count == total - 1 ? ""         : "," ));
+            hprintf(webblk->sock,
+                "{\"devnum\":\"%4.4X\","
+                "\"subchannel\":\"%4.4X\","
+                "\"devclass\":\"%s\","
+                "\"devtype\":\"%4.4X\","
+                "\"status\":\"%s%s%s\","
+                "\"assignment\":",
+                dev->devnum, dev->subchan,
+                devclass,
+                dev->devtype,
+                (dev->fd >= 0       ? "open "    : ""),
+                (dev->busy          ? "busy "    : ""),
+                (IOPENDING(dev)     ? "pending " : ""));
+
+            json_escape_string(webblk->sock, devnam);
+
+            hprintf(webblk->sock,
+                "}%s",
+                (count == total - 1 ? "" : ","));
         }
         count++;
     }
@@ -1970,6 +2053,7 @@ CGITAB cgidir[] =
 
     { "tasks/cmd",           &cgibin_cmd                 },
     { "tasks/syslog",        &cgibin_syslog              },
+    { "tasks/syslog_js",     &cgibin_syslog_js           },
     { "tasks/ipl",           &cgibin_ipl                 },
 
     { "registers/general",   &cgibin_reg_general         },
@@ -1995,3 +2079,4 @@ CGITAB cgidir[] =
 };
 
 /*-------------------------------------------------------------------*/
+

--- a/html/Makefile.am
+++ b/html/Makefile.am
@@ -55,6 +55,7 @@ dist_pkgdata_DATA =   \
     index.html        \
     rexx.html         \
     shared.html       \
+    syslog_js.html    \
     tasks.html        \
     telnet.html
 

--- a/html/Makefile.in
+++ b/html/Makefile.in
@@ -369,6 +369,7 @@ dist_pkgdata_DATA = \
     index.html        \
     rexx.html         \
     shared.html       \
+    syslog_js.html    \
     tasks.html        \
     telnet.html
 

--- a/html/syslog_js.html
+++ b/html/syslog_js.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hercules</title>
+</head>
+<script>
+// Uses the Hercules JSON API to poll log buffer. Maintains index
+// into the buffer so we only pull new lines. Once in the browser
+// the user can PgUp/PgDown through the log AND get to End.
+// Simple Up/Down Arrow command recall is supported.
+// In the event we get a HTTP429 we halve the current refresh rate
+// until data becomes obtainable.
+function initLogViewer() {
+    const COLS = 132;
+    const MAXBUF = 5000;
+    const MAX_COMMAND_HISTORY = 50;
+
+    let index = 0;
+    let buffer = [];
+
+    let follow = true;
+    let start = 0;
+    let timeoutId = null;
+
+    let commandHistory = [];
+    let commandHistoryIndex = -1;
+
+    const log = document.getElementById("log");
+    const commandForm = document.getElementById("syslogCommandForm");
+    const commandInput = document.getElementById("syslogCommandInput");
+    const commandStatus = document.getElementById("syslogCommandStatus");
+    const rateInput = document.getElementById("syslogRefreshInput");
+    const linesInput = document.getElementById("syslogLinesInput");
+    const rateLimitMessage = document.getElementById("syslogRateLimitMessage");
+
+    log.setAttribute("rows", "24");
+    log.tabIndex = 0;
+
+    function visibleRows() {
+        const value = parseInt(linesInput.value, 10);
+        return (!isNaN(value) && value > 0) ? value : 24;
+    }
+
+    function maxStart(rows) {
+        return Math.max(0, buffer.length - rows);
+    }
+
+    function updateFollowState(rows) {
+        if (start >= maxStart(rows)) {
+            start = maxStart(rows);
+            follow = true;
+        }
+    }
+
+    function render() {
+        const rows = visibleRows();
+
+        log.setAttribute("rows", String(rows));
+
+        if (follow) {
+            start = maxStart(rows);
+        }
+
+        if (start < 0) {
+            start = 0;
+        }
+
+        if (start > maxStart(rows)) {
+            start = maxStart(rows);
+        }
+
+        const slice = buffer.slice(start, start + rows);
+
+        const lines = slice.map(line => {
+            let text = String(line);
+            if (text.length > COLS) {
+                text = text.substring(0, COLS);
+            }
+            return text.padEnd(COLS, " ");
+        });
+
+        log.textContent = lines.join("\n");
+    }
+
+    function getRefreshRate() {
+        const value = parseFloat(rateInput.value);
+        return (!isNaN(value) && value >= 0.5) ? value : 5;
+    }
+
+    function applyRefreshRateValidation() {
+        const value = parseFloat(rateInput.value);
+
+        if (isNaN(value) || value < 0.5) {
+            alert("Minimum refresh rate is 0.5 seconds");
+            rateInput.value = "5";
+        }
+
+        scheduleNextFetch();
+    }
+
+    function applyLinesValidation() {
+        const value = parseInt(linesInput.value, 10);
+
+        if (isNaN(value) || value < 5) {
+            alert("Minimum number of lines is 5");
+            linesInput.value = "24";
+        }
+
+        render();
+    }
+
+    function clearRateLimited() {
+        rateLimitMessage.textContent = "";
+    }
+
+    function showRateLimited() {
+        rateLimitMessage.textContent = "Rate Limited";
+        rateLimitMessage.style.color = "red";
+    }
+
+    function applyRateLimitBackoff() {
+        const currentRate = getRefreshRate();
+        const newRate = Math.max(currentRate * 2, 0.5);
+        rateInput.value = String(newRate);
+        showRateLimited();
+    }
+
+    async function doSyslogRequest(options = {}) {
+        const command = options.command ? String(options.command).trim() : "";
+
+        let url = `/cgi-bin/api/v1/syslog?msgcount=0&index=${index}`;
+
+        if (command) {
+            url += `&command=${encodeURIComponent(command)}`;
+        }
+
+        const response = await fetch(url);
+
+        if (response.status === 429) {
+            applyRateLimitBackoff();
+            throw new Error("Rate Limited");
+        }
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        clearRateLimited();
+
+        const data = await response.json();
+
+        if (data.index !== undefined) {
+            index = data.index;
+        }
+
+        if (Array.isArray(data.syslog)) {
+            data.syslog.forEach(line => {
+                if (String(line).trim() !== "") {
+                    buffer.push(String(line));
+                    if (buffer.length > MAXBUF) {
+                        buffer.shift();
+                    }
+                }
+            });
+
+            render();
+        }
+
+        return data;
+    }
+
+    async function fetchLog() {
+        try {
+            await doSyslogRequest();
+        } catch (e) {
+            if (e.message !== "Rate Limited") {
+                console.error("syslog error", e);
+            }
+        }
+
+        scheduleNextFetch();
+    }
+
+    function scheduleNextFetch() {
+        if (timeoutId !== null) {
+            window.clearTimeout(timeoutId);
+        }
+
+        timeoutId = window.setTimeout(fetchLog, getRefreshRate() * 1000);
+    }
+
+    async function sendCommand() {
+        const command = commandInput.value.trim();
+
+        if (!command) {
+            commandStatus.textContent = "Ready";
+            return;
+        }
+
+        if (
+            commandHistory.length === 0 ||
+            commandHistory[commandHistory.length - 1] !== command
+        ) {
+            commandHistory.push(command);
+
+            if (commandHistory.length > MAX_COMMAND_HISTORY) {
+                commandHistory.shift();
+            }
+        }
+
+        commandHistoryIndex = commandHistory.length;
+        commandStatus.textContent = "Sending...";
+
+        try {
+            await doSyslogRequest({ command });
+            commandStatus.textContent = "Command sent";
+            commandInput.value = "";
+            commandInput.focus();
+        } catch (e) {
+            if (e.message === "Rate Limited") {
+                commandStatus.textContent = "Rate Limited";
+            } else {
+                commandStatus.textContent = `Error: ${e.message}`;
+            }
+        }
+
+        scheduleNextFetch();
+    }
+
+    commandForm.addEventListener("submit", (e) => {
+        e.preventDefault();
+        sendCommand();
+    });
+
+    commandInput.addEventListener("keydown", (e) => {
+        if (e.key === "ArrowUp") {
+            e.preventDefault();
+
+            if (commandHistory.length === 0) {
+                return;
+            }
+
+            if (commandHistoryIndex > 0) {
+                commandHistoryIndex--;
+            } else if (
+                commandHistoryIndex === -1 ||
+                commandHistoryIndex >= commandHistory.length
+            ) {
+                commandHistoryIndex = commandHistory.length - 1;
+            }
+
+            commandInput.value = commandHistory[commandHistoryIndex] || "";
+            return;
+        }
+
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+
+            if (commandHistory.length === 0) {
+                return;
+            }
+
+            if (commandHistoryIndex < commandHistory.length - 1) {
+                commandHistoryIndex++;
+                commandInput.value = commandHistory[commandHistoryIndex] || "";
+            } else {
+                commandHistoryIndex = commandHistory.length;
+                commandInput.value = "";
+            }
+            return;
+        }
+
+        if (e.ctrlKey && (e.key === "e" || e.key === "E")) {
+            e.preventDefault();
+            commandInput.value = "";
+            commandHistoryIndex = commandHistory.length;
+            commandStatus.textContent = "Cleared";
+        }
+    });
+
+    rateInput.addEventListener("blur", applyRefreshRateValidation);
+    rateInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+            rateInput.blur();
+        }
+    });
+
+    linesInput.addEventListener("blur", applyLinesValidation);
+    linesInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+            linesInput.blur();
+        }
+    });
+
+    log.addEventListener("keydown", (e) => {
+        const rows = visibleRows();
+
+        if (e.key === "PageUp") {
+            start -= rows;
+            follow = false;
+
+            if (start < 0) {
+                start = 0;
+            }
+
+            render();
+            e.preventDefault();
+        }
+
+        if (e.key === "PageDown") {
+            start += rows;
+
+            if (start > maxStart(rows)) {
+                start = maxStart(rows);
+            }
+
+            updateFollowState(rows);
+            render();
+            e.preventDefault();
+        }
+
+        if (e.key === "End") {
+            follow = true;
+            render();
+            e.preventDefault();
+        }
+    });
+
+    log.addEventListener("wheel", (e) => {
+        e.preventDefault();
+
+        const rows = visibleRows();
+
+        if (e.deltaY > 0) {
+            start += 3;
+
+            if (start > maxStart(rows)) {
+                start = maxStart(rows);
+            }
+
+            updateFollowState(rows);
+        } else {
+            start -= 3;
+            follow = false;
+
+            if (start < 0) {
+                start = 0;
+            }
+        }
+
+        render();
+    }, { passive: false });
+
+    log.addEventListener("click", () => {
+        log.focus();
+    });
+
+    render();
+    fetchLog();
+}
+</script>
+
+<body onload=initLogViewer();>
+<H2>Hercules System Log</H2>
+<div style="overflow:auto">
+<pre id="log" rows="24" cols="132">Loading....</pre>
+</div>
+<form id="syslogCommandForm">
+    <label>Command 
+    <input id="syslogCommandInput" type="text" size="60" maxlength="60">
+    </label>
+    <div>
+        <input type="submit" name="send" value="Send" id="syslogSendButton">
+        <span id="syslogCommandStatus"> Ready</span>
+    </div>
+    <div>
+        <label>Refresh 
+        <input id="syslogRefreshInput" type="text" value="5" pattern="[1-9][0-9]*" size="4">
+        </label>
+        <label> Lines 
+        <input id="syslogLinesInput" type="text" value="24" pattern="[1-9][0-9]*" size="4">
+        </label>
+        <span id="syslogRateLimitMessage"></span>
+    </div>
+</form>
+</body>
+</html>
+

--- a/html/tasks.html
+++ b/html/tasks.html
@@ -7,6 +7,7 @@
 <hr width="100%">
 <h3>Tasks</h3>
 <a href="/cgi-bin/tasks/syslog#bottom" target="main">System Log</a><br>
+<a href="/cgi-bin/tasks/syslog_js" target="main">New System Log</a><br>
 <a href="/cgi-bin/tasks/ipl" target="main">IPL</a><br>
 <hr width="100%">
 <h3>Debugging</h3>

--- a/httpmisc.h
+++ b/httpmisc.h
@@ -96,7 +96,20 @@ struct WEBBLK
 typedef struct WEBBLK   WEBBLK;
 
 /*-------------------------------------------------------------------*/
+/* Constants for http rate limiting window control                   */
+/* sliding time window with a maximum requests per time window       */
+/* Default allows for one request per second + a couple more         */
+/*-------------------------------------------------------------------*/
+#define HTTP_MAX_REQ_PER_INT 12
+#define WINDOW_SIZE_SEC      10
 
+struct RATE_CONTROL 
+{
+    time_t  window_start_time;
+    int     requests_in_window;
+};
+
+/*-------------------------------------------------------------------*/
 typedef void cgibin_func( WEBBLK* webblk );
 
 struct CGITAB

--- a/httpserv.c
+++ b/httpserv.c
@@ -496,7 +496,7 @@ static int http_authenticate(WEBBLK *webblk, char *type, char *userpass)
 /*-------------------------------------------------------------------*/
 /*                         http_download                             */
 /*-------------------------------------------------------------------*/
-static void http_download(WEBBLK *webblk, char *filename)
+void http_download(WEBBLK *webblk, char *filename)
 {
     char buffer[HTTP_PATH_LENGTH];
     char tbuf[80];
@@ -543,6 +543,42 @@ static void http_download(WEBBLK *webblk, char *filename)
 }
 
 /*-------------------------------------------------------------------*/
+/*                          is_rate_limit_needed                     */
+/* implements a sliding window request rate limiting function        */
+/* the time window is fixed (normally a few seconds)                 */
+/* NOTES:                                                            */
+/* Access to static pages is NOT rate limited.                       */
+/* MUST be called with a lock on http_rate_control as requests are   */
+/* handled by separate threads                                       */
+/*-------------------------------------------------------------------*/
+struct RATE_CONTROL http_rate_control = { 0, 0 };
+LOCK   http_rate_lock;
+
+bool is_rate_limit_needed(struct RATE_CONTROL *rate_tab) 
+{
+    time_t now = time(NULL);
+
+    // Initialize window start time on first request
+    if (rate_tab->window_start_time == 0) 
+        rate_tab->window_start_time = now;
+
+    // Reset window if time has passed
+    if (difftime(now, rate_tab->window_start_time) >= WINDOW_SIZE_SEC)
+    {
+        rate_tab->window_start_time = now;
+        rate_tab->requests_in_window = 0;
+    }
+
+    // Check limit
+    if (rate_tab->requests_in_window < HTTP_MAX_REQ_PER_INT)
+    {
+        rate_tab->requests_in_window++;
+        return false; // Allowed
+    }
+
+    return true; // Rate limited
+}
+/*-------------------------------------------------------------------*/
 /*                          http_request                             */
 /*-------------------------------------------------------------------*/
 static void *http_request(void* arg)
@@ -556,6 +592,8 @@ static void *http_request(void* arg)
     CGITAB *cgient;
     int content_length = 0;
     int sock = (int) (uintptr_t) arg;
+    bool rate_limited;
+    int  l;
 
     if(!(webblk = malloc(sizeof(WEBBLK))))
         http_exit(webblk);
@@ -666,9 +704,35 @@ static void *http_request(void* arg)
         http_download(webblk,url);
     else
         url += 9;
-
+    
+    /* check http request rate and give 429 if excessive */
+    obtain_lock( &http_rate_lock );
+    rate_limited = is_rate_limit_needed(&http_rate_control);
+    release_lock( &http_rate_lock );
+    
+    if ( rate_limited ) 
+    {
+        char tbuf[80];
+        
+        USLEEP(200000);     /* pause to help rate limiting */
+        sprintf(tbuf,"Retry-After: %d\n", WINDOW_SIZE_SEC);
+        http_error(webblk, "429 Too Many Requests", tbuf, 
+                    "This request is rate limited");
+    }
+    
+    // at this point url is beyond /cgi-bin/
     while(*url == '/')
         url++;
+    
+    // eat any trailing / characters
+    l = strlen(url);
+    while (l-- > 0) 
+    {
+        if (url[l] == '/')
+            url[l] = '\0';
+        else
+            break;
+    }
 
 #ifdef DEBUG_HTTPSERV
     http_dump_cgi_variables(webblk);
@@ -907,6 +971,8 @@ struct timeval      timeout;            /* timeout value             */
     server.sin_addr.s_addr = INADDR_ANY;
     server.sin_port = http_serv.httpport;
     server.sin_port = htons(server.sin_port);
+    
+    initialize_lock( &http_rate_lock );
 
     http_serv.httpbinddone = FALSE;
     /* Attempt to bind the socket to the port */

--- a/logger.c
+++ b/logger.c
@@ -115,8 +115,16 @@ int bytes_returned;
 
         if (*msgidx >= logger_currmsg)
         {
-            bytes_returned = logger_bufsize - *msgidx;
-            *msgidx = 0;
+            if (logger_wrapped) 
+            {
+                bytes_returned = logger_bufsize - *msgidx;
+                *msgidx = 0;
+            }
+            else
+            {
+                bytes_returned = 0;
+                *msgidx = logger_currmsg;
+            }  
         }
         else
         {


### PR DESCRIPTION
Create new syslog functionality using JavaScript to pull only changed lines from the log. This is added ALONGSIDE the existing syslog interface for compatibility reasons. Entry is via the a New Syslog entry on the tasks menu. The primary reasons for this new version is to prevent the command destruction reported in #804.

Underlying fixes to
-  address the JSON issues reported in #814 and #815. Many thanks to @MockbaTheBorg for assisting with these fixes.
- fix logger incorrectly presenting unwritten nul log data
- extend the JSO syslog api to support an "index" value to allow changed lines to be identified easily.
- prevent 0 refresh times being entered on the console
- implement time window based limiting in the http server for ALL cgi / api calls

