### PR TITLE
Address miscellaneous compiler warnings/issues

### DIFF
--- a/bootstrap.c
+++ b/bootstrap.c
@@ -636,11 +636,11 @@ static BOOL CreateMiniDump( EXCEPTION_POINTERS* pExceptionPtrs )
             );
         }
         else
-            _tprintf( _T("\nMiniDumpWriteDump failed! Error: %u\n\n"), GetLastError() );
+            _tprintf( _T("\nMiniDumpWriteDump failed! Error: %lu\n\n"), GetLastError() );
     }
     else
     {
-        _tprintf( _T("\nCreateFile failed! Error: %u\n\n"), GetLastError() );
+        _tprintf( _T("\nCreateFile failed! Error: %lu\n\n"), GetLastError() );
     }
 
     return bSuccess;

--- a/cgibin.c
+++ b/cgibin.c
@@ -1658,7 +1658,7 @@ void cgibin_api_v1_psw(WEBBLK *webblk)
 /*  /cgi-bin/api/v1/syslog?msgcount=0                                */
 /*  FOREVER                                                          */ 
 /*      /cgi-bin/api/v1/syslog?index=<value_returned_in_JSON_index>  */
-/*      PAUSE a_few_seconds
+/*      PAUSE a_few_seconds                                          */
 /*-------------------------------------------------------------------*/
 void cgibin_api_v1_syslog(WEBBLK *webblk)
 {

--- a/control.c
+++ b/control.c
@@ -3314,7 +3314,7 @@ CREG    savecr12 = 0;                   /* CR12 save                 */
     /* Program check if basic program call is attempting
        to switch into or out of 64-bit addressing mode */
     if ((ete[4] & ETE4_T) == 0
-        && ((ete[4] & ETE4_G) ? 1 : 0) != regs->psw.amode64)
+        && ((ete[4] & ETE4_G) ? 1u : 0u) != regs->psw.amode64)
         ARCH_DEP( program_interrupt )( regs, PGM_SPECIAL_OPERATION_EXCEPTION );
 #endif
     /* Program check if resulting addressing mode is 24 and the
@@ -3476,7 +3476,7 @@ CREG    savecr12 = 0;                   /* CR12 save                 */
 #if defined( FEATURE_TRACING )
 #if defined( FEATURE_001_ZARCH_INSTALLED_FACILITY )
         /* Add a mode trace entry when switching in/out of 64 bit mode */
-        if ((regs->CR( 12 ) & CR12_MTRACE) && (regs->psw.amode64 != ((ete[4] & ETE4_G) ? 1 : 0)))
+        if ((regs->CR( 12 ) & CR12_MTRACE) && (regs->psw.amode64 != ((ete[4] & ETE4_G) ? 1u : 0u)))
         {
             /* since ASN trace might be made already, need to save
                current CR12 and use newcr12 for this second entry */

--- a/ctc_ctci.c
+++ b/ctc_ctci.c
@@ -1195,7 +1195,9 @@ static int  CTCI_EnqueueIPFrame( DEVBLK* pDEVBLK,
 static int  ParseArgs( DEVBLK* pDEVBLK, PCTCBLK pCTCBLK,
                        int argc, char** argx )
 {
+#if !defined( OPTION_W32_CTCI )
     int             saw_if = 0;       /* -if specified               */
+#endif
     int             saw_conf = 0; /* Other configuration flags present */
     struct in_addr  addr;               // Work area for addresses
     int             iMTU;

--- a/ctc_lcs.c
+++ b/ctc_lcs.c
@@ -3272,7 +3272,9 @@ int  ParseArgs( DEVBLK* pDEVBLK, PLCSBLK pLCSBLK,
 #endif
     char            *argn[MAX_ARGS];
     char            **argv = argn;
+#if !defined(OPTION_W32_CTCI)
     int             saw_if = 0;        /* -x (or --if) specified */
+#endif
     int             saw_conf = 0;      /* Other configuration flags present */
     BYTE            bMode = LCSDEV_MODE_IP;      /* Default mode is IP */
 

--- a/ctc_ptp.c
+++ b/ctc_ptp.c
@@ -2579,7 +2579,9 @@ int  parse_conf_stmt( DEVBLK* pDEVBLK, PTPBLK* pPTPBLK,
     HRB             hrb;
     char            *argn[MAX_ARGS];
     char            **argv = argn;
+#if !defined(OPTION_W32_CTCI)
     int             saw_if = 0;        /* -x (or --if) specified */
+#endif
     int             saw_conf = 0;      /* Other configuration flags present */
 
 

--- a/dbgtrace.h
+++ b/dbgtrace.h
@@ -41,8 +41,8 @@
         const char*  func  = __FUNCTION__;                          \
         int          line  = __LINE__;                              \
                                                                     \
-        char*   p = strrchr( file, '\\' );   /* Windows */          \
-        if (!p) p = strrchr( file, '/' );    /* non-Windows */      \
+        const char* p = strrchr( file, '\\' ); /* Windows */        \
+        if (!p) p = strrchr( file, '/' );      /* non-Windows */    \
         if (p) ++p;                                                 \
         if (p) file = p;                                            \
                                                                     \

--- a/dyn76.c
+++ b/dyn76.c
@@ -355,13 +355,13 @@ void ARCH_DEP(hdiagf18_FC) (U32 options, VADR cmpb, REGS *regs)
 #endif
 
     /* Pseudo register contents are cached here once retrieved */
-    U32    R0;
-    U32    R1;
-    U32    R2;
-    U32    R3;
-    U32    R4;
-    U32    R5;
-    U32    R15;
+    U32    R0 = 0;
+    U32    R1 = 0;
+    U32    R2 = 0;
+    U32    R3 = 0;
+    U32    R4 = 0;
+    U32    R5 = 0;
+    U32    R15 = 0;
 
     /* Initialise the LOCK on our first use */
     if (nfile_init_req)

--- a/getopt.c
+++ b/getopt.c
@@ -148,10 +148,8 @@ warnx(const char *fmt, ...)
 /*
  * Compute the greatest common divisor of a and b.
  */
-static int
-gcd(a, b)
-        int a;
-        int b;
+static int 
+gcd(int a, int b)
 {
         int c;
 
@@ -171,11 +169,10 @@ gcd(a, b)
  * in each block).
  */
 static void
-permute_args(panonopt_start, panonopt_end, opt_end, nargv)
-        int panonopt_start;
-        int panonopt_end;
-        int opt_end;
-        char * const *nargv;
+permute_args(int panonopt_start, 
+             int panonopt_end, 
+             int opt_end, 
+             char * const *nargv)
 {
         int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
         char *swap;
@@ -213,10 +210,7 @@ permute_args(panonopt_start, panonopt_end, opt_end, nargv)
  *  Returns -2 if -- is found (can be long option or end of options marker).
  */
 static int
-getopt_internal(nargc, nargv, options)
-        int nargc;
-        char * const *nargv;
-        const char *options;
+getopt_internal(int nargc, char * const *nargv, const char *options)
 {
         char *oli;                              /* option letter list index */
         int optchar;
@@ -358,10 +352,7 @@ start:
  * [eventually this will replace the real getopt]
  */
 DLL_EXPORT int
-getopt(nargc, nargv, options)
-        int nargc;
-        char * const *nargv;
-        const char *options;
+getopt(int nargc, char * const *nargv, const char *options)
 {
         int retval;
 
@@ -391,12 +382,11 @@ getopt(nargc, nargv, options)
  *      Parse argc/argv argument vector.
  */
 DLL_EXPORT int
-getopt_long(nargc, nargv, options, long_options, idx)
-        int nargc;
-        char * const *nargv;
-        const char *options;
-        const struct option *long_options;
-        int *idx;
+getopt_long(int nargc, 
+            char * const *nargv, 
+            const char *options, 
+            const struct option *long_options, 
+            int *idx)
 {
         int retval;
 

--- a/hdl.c
+++ b/hdl.c
@@ -166,7 +166,7 @@ static void* hdl_dlopen( const char* filename, int flag )
     void*   ret;
     size_t  fulllen = 0;
 
-#if defined( HDL_USE_LIBTOOL )
+#if defined( HDL_USE_LIBTOOL ) || defined ( _WIN32 )
     UNREFERENCED( flag );   /* stupid libtool doesn't support flags! */
 #endif
 

--- a/hscutl.c
+++ b/hscutl.c
@@ -1280,7 +1280,7 @@ DLL_EXPORT const char* trimloc( const char* loc )
     ** The below implementation avoids both issues by just returning
     ** a pointer indexed into the current string constant.
     */
-    char* p = strrchr( loc, '\\' );         /* Windows */
+    const char* p = strrchr( loc, '\\' );   /* Windows */
     if (!p) p = strrchr( loc, '/' );        /* non-Windows */
     if (p)
         loc = p+1;

--- a/hstructs.h
+++ b/hstructs.h
@@ -1931,6 +1931,12 @@ struct DEVBLK {                         /* Device configuration block*/
         BYTE    ckdlcount;              /* Locate record count       */
         BYTE    ckdextcd;               /* extended code             */
         void   *cckd_ext;               /* -> CCKD_EXT, else NULL    */
+        /* 
+         * #TODO: MSVC handles bit-field packing by aligning members to the
+         * boundary of their underlying type, inserting padding to ensure fields
+         * do not split across boundaries defined by the type size. Change to
+         * u_int when bumping HDL_VERS_DEVBLK.
+         */
         BYTE    cckd64:1;               /* 1=CCKD64/CFBA64           */
         BYTE    devcache:1;             /* 0 = device cache off
                                            1 = device cache on       */
@@ -1961,6 +1967,7 @@ struct DEVBLK {                         /* Device configuration block*/
         u_int   ckdUCnxt:1;             /* 1=CMDREJ next chained CCW     :AE: */
         u_int   ckdPostRSSD:1;          /* 1=Prev CCW was RSSD           :AE: */
         u_int   ckdPostSSM:1;           /* 1=Prev CCW was SSM            :AE: */
+        /* See #TODO above */
         BYTE    ckdnvs:1;               /* 1=NVS defined             */
         BYTE    ckdraid:1;              /* 1=RAID device             */
         U16     ckdssdlen;              /* #of bytes of data prepared

--- a/ieee.c
+++ b/ieee.c
@@ -779,8 +779,8 @@ static INLINE BYTE ARCH_DEP( float32_signaling_compare )( float32_t op1, float32
 
 #if !defined( _IEEE_NONARCHDEP_ )
 
-#if !defined( HAVE_MATH_H ) && (_MSC_VER < VS2015)
-/* Avoid double definition for VS2015 (albeit with different values). */
+#if !defined( HAVE_MATH_H ) && (_MSC_VER < VS2013)
+/* Avoid double definition for VS2013 (albeit with different values). */
 /* All floating-point numbers can be put in one of these categories.  */
 enum
 {
@@ -790,7 +790,7 @@ enum
     FP_SUBNORMAL    =  3,
     FP_NORMAL       =  4
 };
-#endif /*!defined( HAVE_MATH_H ) && (_MSC_VER < VS2015) */
+#endif /*!defined( HAVE_MATH_H ) && (_MSC_VER < VS2013) */
 
 /*
  * Classify emulated fp values

--- a/loadmem.c
+++ b/loadmem.c
@@ -99,34 +99,34 @@ REGS *regs;
 /*-------------------------------------------------------------------*/
 int loadtext_cmd(int argc, char *argv[], char *cmdline)
 {
-    const char blanks[8]     = {"\x40\x40\x40\x40\x40\x40\x40\x40"};
+    const BYTE blanks[8]     = { 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 };
 
 
     /* Object deck record format headers                             */
     /* (names chosen not to conflict with future GOFF support)       */
 
-    const char c_ObjectESD[9] = {"\xC5\xE2\xC4\x40\x40\x40\x40\x40\x40"};       // ESD - External Symbol Dictionary
-    const char c_ObjectTXT[4]  = {"\xE3\xE7\xE3\x40"};                          // TXT - Text
-    const char c_ObjectRLD[9] = {"\xD9\xD3\xC4\x40\x40\x40\x40\x40\x40"};       // RLD - Relocation Dictionary
-    const char c_ObjectEND[4]  = {"\xC5\xD5\xC4\x40"};                          // END - End
-    const char c_ObjectSYM[9] = {"\xE2\xE8\xD4\x40\x40\x40\x40\x40\x40"};       // SYM - Symbol
+    const BYTE c_ObjectESD[9] = { 0xC5, 0xE2, 0xC4, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 }; // ESD - External Symbol Dictionary
+    const BYTE c_ObjectTXT[4] = { 0xE3, 0xE7, 0xE3, 0x40 };                               // TXT - Text
+    const BYTE c_ObjectRLD[9] = { 0xD9, 0xD3, 0xC4, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 }; // RLD - Relocation Dictionary
+    const BYTE c_ObjectEND[4] = { 0xC5, 0xD5, 0xC4, 0x40 };                               // END - End
+    const BYTE c_ObjectSYM[9] = { 0xE2, 0xE8, 0xD4, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40 }; // SYM - Symbol
 
 
     /* Special control directives from VM                            */
 
-    const char c_ObjectCPB[3]  = {"\xC3\xD7\xC2"};                              // CPB - Conditional Page Boundary
-    const char c_ObjectDEL[3]  = {"\xC4\xD5\xD3"};                              // DEL - Delete
-    const char c_ObjectICS[3]  = {"\xC9\xC3\xE2"};                              // ICS - Include Control Section
-    const char c_ObjectLDT[3]  = {"\xD3\xC4\xE3"};                              // LDT - Loader Termination
-    const char c_ObjectPAD[3]  = {"\xD7\xC1\xC4"};                              // PAD - Padding
-    const char c_ObjectPRT[3]  = {"\xD7\xD8\xE3"};                              // PRT - Printer
-    const char c_ObjectPRM[3]  = {"\xD7\xD8\xD4"};                              // PRM - Parameter
-    const char c_ObjectREP[3]  = {"\xD9\xC5\xD7"};                              // REP - Replace
-    const char c_ObjectSLC[3]  = {"\xE2\xD3\xC3"};                              // SLC - Set Location Counter
-    const char c_ObjectSPB[3]  = {"\xE1\xD7\xC2"};                              // SPB - Set Page Boundary
-    const char c_ObjectSYS[3]  = {"\xE1\xE8\xE1"};                              // SYS - Subsystem
-    const char c_ObjectUPB[3]  = {"\xE4\xD7\xC2"};                              // UPB - Unconditional Page Boundary
-    const char c_ObjectVER[3]  = {"\xE5\xC5\xD8"};                              // VER - Verify
+    const BYTE c_ObjectCPB[3]  = { 0xC3, 0xD7, 0xC2 };                          // CPB - Conditional Page Boundary
+    const BYTE c_ObjectDEL[3]  = { 0xC4, 0xD5, 0xD3 };                          // DEL - Delete
+    const BYTE c_ObjectICS[3]  = { 0xC9, 0xC3, 0xE2 };                          // ICS - Include Control Section
+    const BYTE c_ObjectLDT[3]  = { 0xD3, 0xC4, 0xE3 };                          // LDT - Loader Termination
+    const BYTE c_ObjectPAD[3]  = { 0xD7, 0xC1, 0xC4 };                          // PAD - Padding
+    const BYTE c_ObjectPRT[3]  = { 0xD7, 0xD8, 0xE3 };                          // PRT - Printer
+    const BYTE c_ObjectPRM[3]  = { 0xD7, 0xD8, 0xD4 };                          // PRM - Parameter
+    const BYTE c_ObjectREP[3]  = { 0xD9, 0xC5, 0xD7 };                          // REP - Replace
+    const BYTE c_ObjectSLC[3]  = { 0xE2, 0xD3, 0xC3 };                          // SLC - Set Location Counter
+    const BYTE c_ObjectSPB[3]  = { 0xE1, 0xD7, 0xC2 };                          // SPB - Set Page Boundary
+    const BYTE c_ObjectSYS[3]  = { 0xE1, 0xE8, 0xE1 };                          // SYS - Subsystem
+    const BYTE c_ObjectUPB[3]  = { 0xE4, 0xD7, 0xC2 };                          // UPB - Unconditional Page Boundary
+    const BYTE c_ObjectVER[3]  = { 0xE5, 0xC5, 0xD8 };                          // VER - Verify
 
 
     /* Define byte tests for general record types                    */

--- a/msgenu.h
+++ b/msgenu.h
@@ -216,10 +216,10 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp, bool quiet )
 #define MSG( id, sev, ... )     #id "%s " id "\n", sev,           ## __VA_ARGS__
 #define MSG_C( id, sev, ... )   #id "%s " id "",   sev,           ## __VA_ARGS__
 
-#if defined( _MSVC_ )// MS Windows
+#if defined( _MSVC_ ) && !defined(__clang__) // MS Windows
   #define EXTGUIMSG( ... )      send2gui(                         ## __VA_ARGS__ )
 #else // fucking linux
-  #define EXTGUIMSG( ... )      send2gui(                          # __VA_ARGS__ )
+  #define EXTGUIMSG( ... )      send2gui(                            __VA_ARGS__ )
 #endif
 
 /*-------------------------------------------------------------------*/

--- a/netsupp.c
+++ b/netsupp.c
@@ -380,6 +380,8 @@ int read_tuntap( int fd, BYTE* buffer, size_t nBuffLen, int secs )
     if (rc == 0)
         return 0;
 
+#else
+    UNREFERENCED(secs);
 #endif // !defined( OPTION_W32_CTCI ) // (i.e. Linux only)
 
     nBytesRead = TUNTAP_Read( fd, buffer, nBuffLen );

--- a/opcode.h
+++ b/opcode.h
@@ -2996,7 +2996,7 @@ DEF_INST( move_long_unicode );
 DEF_INST( compare_logical_long_unicode );
 #endif
 
-#if defined( FEATURE_017_MSA_FACILITY )
+#if defined( FEATURE_017_MSA_FACILITY ) && !defined( DYNINST_017_MSA_FACILITY )
 DEF_INST( cipher_message );
 DEF_INST( cipher_message_with_chaining );
 DEF_INST( compute_intermediate_message_digest );
@@ -3491,7 +3491,7 @@ DEF_INST( load_logical_and_zero_rightmost_byte );
 DEF_INST( load_and_zero_rightmost_byte );
 #endif
 
-#if defined( FEATURE_057_MSA_EXTENSION_FACILITY_5 )
+#if defined( FEATURE_057_MSA_EXTENSION_FACILITY_5 ) && !defined( DYNINST_057_MSA_EXTENSION_FACILITY_5 )
 DEF_INST( perform_random_number_operation );
 #endif
 
@@ -3557,11 +3557,11 @@ DEF_INST( transaction_begin );
 DEF_INST( store_hypervisor_information );
 #endif
 
-#if defined( FEATURE_076_MSA_EXTENSION_FACILITY_3 )
+#if defined( FEATURE_076_MSA_EXTENSION_FACILITY_3 ) && !defined( DYNINST_076_MSA_EXTENSION_FACILITY_3 )
 DEF_INST( perform_cryptographic_key_management_operation );
 #endif
 
-#if defined( FEATURE_077_MSA_EXTENSION_FACILITY_4 )
+#if defined( FEATURE_077_MSA_EXTENSION_FACILITY_4 ) && !defined( DYNINST_077_MSA_EXTENSION_FACILITY_4 )
 DEF_INST( perform_cryptographic_computation );
 DEF_INST( cipher_message_with_cipher_feedback );
 DEF_INST( cipher_message_with_output_feedback );

--- a/tfprint.c
+++ b/tfprint.c
@@ -4239,7 +4239,7 @@ static void parse_option_codepage( const char* optname )
 /*-------------------------------------------------------------------*/
 static void parse_tracefile( const char* filename )
 {
-    off_t  off_size;    // (file size)
+    off_t  off_size = 0; // (file size)
 
     /* ALWAYS save the filename if it was provided to us */
     hostpath( pathname, filename, sizeof( pathname ));

--- a/transact.c
+++ b/transact.c
@@ -237,6 +237,8 @@ bool        per_tend = false;           /* true = check for PER TEND */
 
     S( inst, regs, b2, effective_addr2 );
 
+    UNREFERENCED( effective_addr2 );
+
     TXF_SIE_INTERCEPT( regs, TEND );
 
     TXF_EXECUTE_INSTR_CHECK( regs );
@@ -708,6 +710,8 @@ int     b1;                             /* Base of effective addr    */
 VADR    effective_addr1;                /* Effective address         */
 
     SIL( inst, regs, i2, b1, effective_addr1 );
+
+    UNREFERENCED( effective_addr1 );
 
     TXF_SIE_INTERCEPT( regs, TBEGINC );
 

--- a/tt32api.h
+++ b/tt32api.h
@@ -24,7 +24,7 @@
 #ifndef _TT32API_H_
 #define _TT32API_H_
 
-#include "TT32if.h"
+#include "tt32if.h"
 
 /////////////////////////////////////////////////////////////////////////////////////////
 //                            TunTap32.dll name

--- a/tuntap.c
+++ b/tuntap.c
@@ -177,6 +177,8 @@ static int TUNTAP_SetMode (int fd, struct hifr *hifr, int iFlags)
         waitpid (pid, &status, 0);
         errno = sv_err;
     }
+#else
+    UNREFERENCED(iFlags);
 #endif /* if !defined( OPTION_W32_CTCI ) */
 
     return rc;

--- a/vstore.h
+++ b/vstore.h
@@ -172,8 +172,9 @@
 /*-------------------------------------------------------------------*/
 inline void concpy( REGS* regs, void* d, void* s, int n )
 {
-    BYTE* u8d = d;
-    BYTE* u8s = s;
+    BYTE* u8d = (BYTE*)d;
+    BYTE* u8s = (BYTE*)s;
+    ptrdiff_t d1;
 
     /* Copy until ready or 8 byte integral boundary */
     while (n && ((uintptr_t) u8d & 7))
@@ -212,7 +213,7 @@ inline void concpy( REGS* regs, void* d, void* s, int n )
 #endif // end code for 32-bit builds
 
     /* Copy double words on enough length and src - dst distance */
-    if (n && labs( u8d - u8s ) > 7)
+    if (n && (d1 = u8d - u8s, d1 > 7 || d1 < -7))
     {
         while(n > 7)
         {
@@ -244,6 +245,7 @@ inline void concpy_rl( REGS* regs, void* d, void* s, int n )
 {
     BYTE* u8d = (BYTE*)d + n;
     BYTE* u8s = (BYTE*)s + n;
+    ptrdiff_t d1;
 
     /* Copy until ready or 8 byte integral boundary */
     while (n && ((uintptr_t) u8d & 7))
@@ -282,7 +284,7 @@ inline void concpy_rl( REGS* regs, void* d, void* s, int n )
 #endif // end code for 32-bit builds
 
     /* Copy double words on enough length and (src - dst) distance */
-    if (n && labs( u8d - u8s ) > 7)
+    if (n && (d1 = u8d - u8s, d1 > 7 || d1 < -7))
     {
         while (n > 7)
         {

--- a/w32stape.c
+++ b/w32stape.c
@@ -53,11 +53,10 @@ static  LOCK    g_lock; // (master global access lock)
 
 static void obtain_w32stape_lock()
 {
-    static int bDidInit  = 0;
-    static int bInitBusy = 1;
-    if (!bDidInit)
+    static LONG bDidInit  = 0;
+    static LONG bInitBusy = 1;
+    if (!InterlockedCompareExchange(&bDidInit, 1, 0))
     {
-        bDidInit = 1;
         initialize_lock ( &g_lock );
         memset( g_ifds,    0,    sizeof ( g_ifds    ) );
         memset( g_handles, 0,    sizeof ( g_handles ) );

--- a/zvector2.c
+++ b/zvector2.c
@@ -211,17 +211,6 @@ facility  code  test#   Instruction                                             
     #endif
 #endif
 
-/*-------------------------------------------------------------------*/
-/* 128 bit types                                                     */
-/*-------------------------------------------------------------------*/
-
-/*-------------------------------------------------------------------*/
-/* are the compiler 128 bit types available?                         */
-/*-------------------------------------------------------------------*/
-#if defined( __SIZEOF_INT128__ )
-    #define _USE_128_
-#endif
-
 /*===================================================================*/
 /* LOCAL Registers (saved vector registers)                          */
 /*     local vector registers ensure source input of a vector        */


### PR DESCRIPTION
This PR looks through *all* compiler warnings generated by MSVC and clang-cl (including Windows ARM64) and picks the low hanging fruit. While many of the changes are low value (e.g., non-referenced parameters and sign/unsigned mismatches), it did catch a potential truncation issue in vstore.h

In addition, building Hercules on more modern C compilers (e.g., gcc 15.2, gcc 16.0.1, and clang 22.1.1) will generate a few new warnings that are addressed in this PR. Vanilla x64 Fedora/Ubuntu builds of Hercules will still generate a few warnings, however, many look like static analysis false positives.