### PR TITLE
Fix errors reported by valgrind

### DIFF
--- a/cckddasd.c
+++ b/cckddasd.c
@@ -4130,6 +4130,8 @@ void cckd_sf_parse_sfn( DEVBLK* dev, char* sfn )
     char pathname[MAX_PATH];
     if ('\"' == sfn[0]) sfn++;
     hostpath(pathname, sfn, sizeof(pathname));
+
+    if (dev->dasdsfn) free (dev->dasdsfn);
     dev->dasdsfn = strdup(pathname);
     if (dev->dasdsfn)
     {

--- a/cckddasd64.c
+++ b/cckddasd64.c
@@ -2551,7 +2551,7 @@ int             sfx,L1idx,l2x;          /* Lookup table indices      */
     L1idx = trk >> 8;
     l2x = trk & 0xff;
 
-    if (l2 != NULL) l2->L2_trkoff = l2->L2_len = l2->L2_size = 0;
+    if (l2 != NULL) l2->L2_trkoff = l2->L2_len = l2->L2_size = l2->L2_pad = 0;
 
     for (sfx = cckd->sfn; sfx >= 0; sfx--)
     {
@@ -2732,6 +2732,7 @@ int             size;                   /* Size of new track         */
         l2.L2_trkoff = off;
         l2.L2_len    = (U16)len;
         l2.L2_size   = (U16)size;
+        l2.L2_pad    = 0;
 
         if (1
             && oldl2.L2_trkoff != CCKD64_NOSIZE
@@ -2753,6 +2754,7 @@ int             size;                   /* Size of new track         */
     {
         l2.L2_trkoff = 0;
         l2.L2_len = l2.L2_size = (U16)len;
+        l2.L2_pad    = 0;
     }
 
     /* Update the level 2 entry */

--- a/cckddasd64.c
+++ b/cckddasd64.c
@@ -2267,6 +2267,9 @@ CCKD64_FREEBLK *fsp = NULL;             /* -> new format free space  */
 
         if (fpos)
         {
+            /* Zero entire block to avoid writing garbage to underlying file */
+            memset (&fsp[0], 0, CCKD64_FREEBLK_SIZE);
+
             /* New format free space */
             memcpy (&fsp[0], "FREE_BLK", 8);
             ppos = cckd->cdevhdr[sfx].free_off;

--- a/cckdutil64.c
+++ b/cckdutil64.c
@@ -2622,6 +2622,9 @@ cdsk_fsperr_retry:
 
             if (off)
             {
+                /* Zero entire block to avoid writing garbage to underlying file */
+                memset (fsp, 0, CCKD64_FREEBLK_SIZE);
+
                 /* new format free space */
                 memcpy (fsp, "FREE_BLK", 8);
                 for (i = 0, j = 1; spctab[i].spc_typ != SPCTAB_EOF; i++)

--- a/config.c
+++ b/config.c
@@ -1384,6 +1384,8 @@ int     i;                              /* Loop index                */
         */
         if (dev->buf && dev->buf == dev->prev_buf)
             free_aligned( dev->buf );
+        else if (dev->prev_buf)
+            free_aligned( dev->prev_buf );
 
         dev->buf = dev->prev_buf = malloc_aligned( dev->bufsize, _4K );
 

--- a/control.c
+++ b/control.c
@@ -3739,6 +3739,10 @@ int     rc;                             /* return code from load_psw */
 
     /* Now INVALIDATE ALL TLB ENTRIES in our working copy.. */
     memset( &newregs.tlb.vaddr, 0, TLBN * sizeof(DW) );
+
+    /* Including the Address Space Designator checks */
+    memset( &newregs.tlb.asd, 0, TLBN * sizeof(DW) );
+    memset( &newregs.tlb.common, 0, TLBN * sizeof(BYTE) );
     newregs.tlbID = 1;
 
     /* Set the breaking event address register in the copy */

--- a/ctc_lcs.c
+++ b/ctc_lcs.c
@@ -3379,6 +3379,7 @@ int  ParseArgs( DEVBLK* pDEVBLK, PLCSBLK pLCSBLK,
                 return -1;
             }
 
+            if ( pLCSBLK->pszTUNDevice ) { free( pLCSBLK->pszTUNDevice ); }
             pLCSBLK->pszTUNDevice = strdup( optarg );
             break;
 
@@ -3418,6 +3419,7 @@ int  ParseArgs( DEVBLK* pDEVBLK, PLCSBLK pLCSBLK,
 
         case 'o':
 
+            if ( pLCSBLK->pszOATFilename ) { free( pLCSBLK->pszOATFilename ); }
             pLCSBLK->pszOATFilename = strdup( optarg );
             saw_conf = 1;
             break;

--- a/ecpsvm.c
+++ b/ecpsvm.c
@@ -364,6 +364,7 @@ struct _ECPSVM_SASTATS
     BYTE micevma2; \
     BYTE micevma3; \
     BYTE micevma4; \
+    buf[0] = '\0'; /* Ensure null delimited for STRLCAT */ \
     if(SIE_STATE(regs)) \
         return(1); \
     if(!PROBSTATE(&regs->psw)) \

--- a/hscemode.c
+++ b/hscemode.c
@@ -2036,11 +2036,6 @@ int auto_trace_cmd( int argc, char* argv[], char* cmdline )
     return 0;
 }
 
-#if defined( SUPPRESS_128BIT_PRINTF_FORMAT_WARNING )
-PUSH_GCC_WARNINGS()
-DISABLE_GCC_WARNING( "-Wformat" )
-#endif
-
 /*-------------------------------------------------------------------*/
 /* ipending command - display pending interrupts                     */
 /*-------------------------------------------------------------------*/
@@ -2235,10 +2230,10 @@ int ipending_cmd(int argc, char *argv[], char *cmdline)
     }
 
     // "config mask "F_CPU_BITMAP" started mask "F_CPU_BITMAP" waiting mask "F_CPU_BITMAP
-    WRMSG( HHC00870, "I", sysblk.config_mask, sysblk.started_mask, sysblk.waiting_mask );
+    WRMSG( HHC00870, "I", F_CPU_BITARG(sysblk.config_mask), F_CPU_BITARG(sysblk.started_mask), F_CPU_BITARG(sysblk.waiting_mask) );
 
     // "syncbc mask "F_CPU_BITMAP" %s"
-    WRMSG( HHC00871, "I", sysblk.sync_mask, sysblk.syncing ? "sync in progress" : "" );
+    WRMSG( HHC00871, "I", F_CPU_BITARG(sysblk.sync_mask), sysblk.syncing ? "sync in progress" : "" );
 
     WRMSG( HHC00872, "I", test_lock(&sysblk.sigplock) ? "" : "not ");
     WRMSG( HHC00873, "I", test_lock(&sysblk.todlock) ? "" : "not ");
@@ -2364,11 +2359,6 @@ int ipending_cmd(int argc, char *argv[], char *cmdline)
 
     return 0;
 }
-
-#if defined( SUPPRESS_128BIT_PRINTF_FORMAT_WARNING )
-POP_GCC_WARNINGS()
-#endif
-
 
 /*-------------------------------------------------------------------*/
 /* bear command - display or alter BEAR register                     */

--- a/hstructs.h
+++ b/hstructs.h
@@ -90,6 +90,10 @@
 /*  bits.  ... There is no support in GCC for expressing an integer  */
 /*  constant of type __int128 for targets with long long integer     */
 /*  less than 128 bits wide."                                        */
+/*                                                                   */
+/* In addition to not having adequate __uint128_t s/p-rintf format   */
+/* support, the macro F_CPU_BITARG is introduced for values used by  */
+/* F_CPU_BITMAP. Decomposing 128-bit types to 64-bit when required.  */
 /*-------------------------------------------------------------------*/
 
 #if MAX_CPU_ENGS <= 0
@@ -97,14 +101,15 @@
 #elif MAX_CPU_ENGS <= 32
     typedef U32                 CPU_BITMAP;
     #define F_CPU_BITMAP        "%8.8"PRIX32
+    #define F_CPU_BITARG(X)     (CPU_BITMAP)(X)
 #elif MAX_CPU_ENGS <= 64
     typedef U64                 CPU_BITMAP;
     #define F_CPU_BITMAP        "%16.16"PRIX64
+    #define F_CPU_BITARG(X)     (CPU_BITMAP)(X)
 #elif MAX_CPU_ENGS <= 128
-  typedef __uint128_t         CPU_BITMAP;
-  // ZZ FIXME: No printf format support for __uint128_t yet, so we will incorrectly display...
-  #define SUPPRESS_128BIT_PRINTF_FORMAT_WARNING
-  #define F_CPU_BITMAP        "%16.16"PRIX64
+    typedef __uint128_t         CPU_BITMAP;
+    #define F_CPU_BITMAP        "%016"PRIx64 "%016"PRIx64
+    #define F_CPU_BITARG(X)     (U64)((X) >> 64), (U64)(X)
 #else
   #error MAX_CPU_ENGS cannot exceed 128
 #endif

--- a/impl.c
+++ b/impl.c
@@ -1558,6 +1558,9 @@ int     rc;
     /* Initialize runtime opcode tables */
     init_runtime_opcode_tables();
 
+    /* Initialize command line history */
+    history_init();
+
     /* Initialize the Hercules Dynamic Loader (HDL) */
     rc = hdl_main
     (

--- a/panel.c
+++ b/panel.c
@@ -240,10 +240,10 @@ static FILE *confp   = NULL;            /* Console file pointer      */
 
 typedef struct _PANMSG      /* Panel message control block structure */
 {
-    struct _PANMSG*     next;           /* --> next entry in chain   */
-    struct _PANMSG*     prev;           /* --> prev entry in chain   */
-    int                 msgnum;         /* msgbuf 0-relative entry#  */
-    char                msg[MSG_SIZE];  /* text of panel message     */
+    struct _PANMSG*     next;               /* --> next entry in chain   */
+    struct _PANMSG*     prev;               /* --> prev entry in chain   */
+    int                 msgnum;             /* msgbuf 0-relative entry#  */
+    char                msg[MSG_SIZE + 1];  /* text of panel message     */
 }
 PANMSG;                     /* Panel message control block structure */
 
@@ -1793,6 +1793,7 @@ size_t  loopcount;                      /* Number of iterations done */
         curmsg->prev = curmsg - 1;
         curmsg->msgnum = i;
         memset(curmsg->msg,SPACE,MSG_SIZE);
+        curmsg->msg[MSG_SIZE] = '\0';
     }
 
     /* Complete the circle */
@@ -2920,6 +2921,7 @@ FinishShutdown:
 
                 /* Copy message into next available PANMSG slot */
                 memcpy( curmsg->msg, readbuf, MSG_SIZE );
+                curmsg->msg[MSG_SIZE] = '\0';
 
             } /* end if (!readoff || readoff >= MSG_SIZE) */
         } /* end Read message bytes until newline... */

--- a/panel.c
+++ b/panel.c
@@ -1838,6 +1838,7 @@ size_t  loopcount;                      /* Number of iterations done */
         curr_int_start_time = time( NULL );
 
     prev_int_start_time = curr_int_start_time;
+    memset( prev_psw, 0, sizeof( prev_psw ) );
 
     /* Process messages and commands */
     for (loopcount = 0; ; loopcount++)

--- a/panel.c
+++ b/panel.c
@@ -1741,8 +1741,6 @@ size_t  loopcount;                      /* Number of iterations done */
     // panel cleanup is now handled directly in the panel thread.
     //hdl_addshut( "panel_cleanup", panel_cleanup, NULL );
 
-    history_init();
-
 #if defined(HAVE_REGEX_H) || defined(HAVE_PCRE)
     init_HHC_regexp();
 #endif

--- a/w32util.c
+++ b/w32util.c
@@ -4664,6 +4664,7 @@ void w32_parse_piped_process_stdxxx_data ( PIPED_PROCESS_CTL* pPipedProcessCtl, 
 
 #define  MS_VC_EXCEPTION   0x406D1388       // (special value)
 
+#pragma pack(push,8)
 typedef struct tagTHREADNAME_INFO
 {
     DWORD   dwType;         // must be 0x1000
@@ -4672,6 +4673,7 @@ typedef struct tagTHREADNAME_INFO
     DWORD   dwFlags;        // reserved for future use, must be zero
 }
 THREADNAME_INFO;
+#pragma pack(pop)
 
 DLL_EXPORT void w32_set_thread_name( TID tid, const char* name )
 {
@@ -4684,14 +4686,17 @@ DLL_EXPORT void w32_set_thread_name( TID tid, const char* name )
     info.dwThreadID = (DWORD)tid;   // (-1 == current thread, else tid)
     info.dwFlags    = 0;
 
+#pragma warning(push)
+#pragma warning(disable: 6320 6322)
     __try
     {
-        RaiseException( MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (const U_LONG_PTR*)&info );
+        RaiseException( MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(U_LONG_PTR), (const U_LONG_PTR*)&info );
     }
     __except ( EXCEPTION_CONTINUE_EXECUTION )
     {
         /* (do nothing) */
     }
+#pragma warning(pop)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR investigated running Hercules on the test suite, VM/370 Community Edition, etc., under a variety of valgrind (mainly memcheck) configurations. To quickly reproduce these findings, [func_exec_program_core](https://github.com/SDL-Hercules-390/hyperion/blob/ad45f43097f92a6e6d6621160cb53f4c65474fbe/autoconf/ltmain.sh#L5328) in the libtool script can be modified, e.g:

```sh
exec valgrind -s --track-origins=yes --leak-check=full --show-leak-kinds=all --keep-debuginfo=yes --log-file=valgrind_out.txt "$progdir/$program" ${1+"$@"}
```

Much of my testing was surface-level, and I did not thoroughly exhaust all code paths, features, or interactions (esp. around networking or long-running scenarios that perform meaningful work). There may be more wins available[^1].

A few changes in this PR can be implemented differently, e.g., see 'cckddasd.c: ensure dasdsfn is free'd', so care is required.

---

Additional comments:

1. WIP: comm3705.c: use-after-free on close: https://github.com/gottfriedleibniz/hyperion/commit/77f5b7c8b273dc56063e846b8a8437009aef3f48.

[^1]: If this PR remains open for a longer period, I’ll include additional findings here. Valgrind slows things down considerably, which makes testing anything real-world a bit frustrating ~~(I haven’t discovered anything meaningful with ASan yet)~~.
