### PR TITLE
Add WebSocket console transport (WSCNSLPORT) alongside the existing telnet console

### DIFF
--- a/Hercules_VS2008.vcproj
+++ b/Hercules_VS2008.vcproj
@@ -434,6 +434,10 @@
 								RelativePath=".\cnsllogo.h"
 								>
 							</File>
+							<File
+								RelativePath=".\wscnsl.h"
+								>
+							</File>
 						</Filter>
 						<Filter
 							Name="Source Files"
@@ -444,6 +448,10 @@
 							</File>
 							<File
 								RelativePath=".\console.c"
+								>
+							</File>
+							<File
+								RelativePath=".\wscnsl.c"
 								>
 							</File>
 						</Filter>

--- a/Hercules_VS2015.vcxproj
+++ b/Hercules_VS2015.vcxproj
@@ -320,6 +320,7 @@
     <ClCompile Include="con1052c.c" />
     <ClCompile Include="config.c" />
     <ClCompile Include="console.c" />
+    <ClCompile Include="wscnsl.c" />
     <ClCompile Include="conspawn.c" />
     <ClCompile Include="control.c" />
     <ClCompile Include="cpu.c" />
@@ -1688,6 +1689,7 @@
     <ClInclude Include="w32mtio.h" />
     <ClInclude Include="w32stape.h" />
     <ClInclude Include="w32util.h" />
+    <ClInclude Include="wscnsl.h" />
     <ClInclude Include="x75.h" />
     <ClInclude Include="zfcp.h" />
     <ClInclude Include="zvector.h" />

--- a/Hercules_VS2015.vcxproj.filters
+++ b/Hercules_VS2015.vcxproj.filters
@@ -354,6 +354,9 @@
     <ClCompile Include="console.c">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="wscnsl.c">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="comm3705.c">
       <Filter>Source Files\Hercules\Devices\CTC\Source Files</Filter>
     </ClCompile>
@@ -4052,6 +4055,9 @@
       <Filter>Source Files\Hercules\ExtPkgs\crypto\include</Filter>
     </ClInclude>
     <ClInclude Include="cnsllogo.h">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wscnsl.h">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="comm3705.h">

--- a/Hercules_VS2017.vcxproj
+++ b/Hercules_VS2017.vcxproj
@@ -320,6 +320,7 @@
     <ClCompile Include="con1052c.c" />
     <ClCompile Include="config.c" />
     <ClCompile Include="console.c" />
+    <ClCompile Include="wscnsl.c" />
     <ClCompile Include="conspawn.c" />
     <ClCompile Include="control.c" />
     <ClCompile Include="cpu.c" />
@@ -1688,6 +1689,7 @@
     <ClInclude Include="w32mtio.h" />
     <ClInclude Include="w32stape.h" />
     <ClInclude Include="w32util.h" />
+    <ClInclude Include="wscnsl.h" />
     <ClInclude Include="x75.h" />
     <ClInclude Include="zfcp.h" />
     <ClInclude Include="zvector.h" />

--- a/Hercules_VS2017.vcxproj.filters
+++ b/Hercules_VS2017.vcxproj.filters
@@ -354,6 +354,9 @@
     <ClCompile Include="console.c">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="wscnsl.c">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="comm3705.c">
       <Filter>Source Files\Hercules\Devices\CTC\Source Files</Filter>
     </ClCompile>
@@ -4052,6 +4055,9 @@
       <Filter>Source Files\Hercules\ExtPkgs\crypto\include</Filter>
     </ClInclude>
     <ClInclude Include="cnsllogo.h">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wscnsl.h">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="comm3705.h">

--- a/Hercules_VS2019.vcxproj
+++ b/Hercules_VS2019.vcxproj
@@ -320,6 +320,7 @@
     <ClCompile Include="con1052c.c" />
     <ClCompile Include="config.c" />
     <ClCompile Include="console.c" />
+    <ClCompile Include="wscnsl.c" />
     <ClCompile Include="conspawn.c" />
     <ClCompile Include="control.c" />
     <ClCompile Include="cpu.c" />
@@ -1688,6 +1689,7 @@
     <ClInclude Include="w32mtio.h" />
     <ClInclude Include="w32stape.h" />
     <ClInclude Include="w32util.h" />
+    <ClInclude Include="wscnsl.h" />
     <ClInclude Include="x75.h" />
     <ClInclude Include="zfcp.h" />
     <ClInclude Include="zvector.h" />

--- a/Hercules_VS2019.vcxproj.filters
+++ b/Hercules_VS2019.vcxproj.filters
@@ -354,6 +354,9 @@
     <ClCompile Include="console.c">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="wscnsl.c">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="comm3705.c">
       <Filter>Source Files\Hercules\Devices\CTC\Source Files</Filter>
     </ClCompile>
@@ -4052,6 +4055,9 @@
       <Filter>Source Files\Hercules\ExtPkgs\crypto\include</Filter>
     </ClInclude>
     <ClInclude Include="cnsllogo.h">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wscnsl.h">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="comm3705.h">

--- a/Hercules_VS2022.vcxproj
+++ b/Hercules_VS2022.vcxproj
@@ -320,6 +320,7 @@
     <ClCompile Include="con1052c.c" />
     <ClCompile Include="config.c" />
     <ClCompile Include="console.c" />
+    <ClCompile Include="wscnsl.c" />
     <ClCompile Include="conspawn.c" />
     <ClCompile Include="control.c" />
     <ClCompile Include="cpu.c" />
@@ -1688,6 +1689,7 @@
     <ClInclude Include="w32mtio.h" />
     <ClInclude Include="w32stape.h" />
     <ClInclude Include="w32util.h" />
+    <ClInclude Include="wscnsl.h" />
     <ClInclude Include="x75.h" />
     <ClInclude Include="zfcp.h" />
     <ClInclude Include="zvector.h" />

--- a/Hercules_VS2022.vcxproj.filters
+++ b/Hercules_VS2022.vcxproj.filters
@@ -354,6 +354,9 @@
     <ClCompile Include="console.c">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="wscnsl.c">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="comm3705.c">
       <Filter>Source Files\Hercules\Devices\CTC\Source Files</Filter>
     </ClCompile>
@@ -4052,6 +4055,9 @@
       <Filter>Source Files\Hercules\ExtPkgs\crypto\include</Filter>
     </ClInclude>
     <ClInclude Include="cnsllogo.h">
+      <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wscnsl.h">
       <Filter>Source Files\Hercules\Devices\Con/Disp/Term\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="comm3705.h">

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ dyndev_SRC =  \
   tcpnje.c    \
   con1052c.c  \
   console.c   \
+  wscnsl.c    \
   ctc_ctci.c  \
   ctc_lcs.c   \
   ctc_ptp.c   \
@@ -306,7 +307,7 @@ hdt3088_la_SOURCES  = ctc_lcs.c ctc_ctci.c ctcadpt.c tuntap.c netsupp.c
 hdt3088_la_LDFLAGS  = $(DYNMOD_LD_FLAGS)
 hdt3088_la_LIBADD   = $(DYNMOD_LD_ADD)
 
-hdt3270_la_SOURCES  = console.c
+hdt3270_la_SOURCES  = console.c wscnsl.c
 hdt3270_la_LDFLAGS  = $(DYNMOD_LD_FLAGS)
 hdt3270_la_LIBADD   = $(DYNMOD_LD_ADD)
 
@@ -1127,6 +1128,7 @@ noinst_HEADERS =          \
   vmd250.h                \
   vstore.h                \
   vsvers.h                \
+  wscnsl.h                \
   w32ctca.c               \
   w32ctca.h               \
   w32dl.h                 \

--- a/cmdtab.h
+++ b/cmdtab.h
@@ -1702,6 +1702,22 @@
 
 #define sysgport_cmd_desc       "Define SYSG console port"
 
+#define wscnslport_cmd_desc     "Define WebSocket console port"
+#define wscnslport_cmd_help                                                     \
+                                                                                \
+  "Format:    \"wscnslport [port|host:port|NO]\"\n"                             \
+  "\n"                                                                          \
+  "Defines the listening port (and optionally the binding host) for the\n"      \
+  "WebSocket variant of the console. WebSocket console connections carry\n"     \
+  "exactly the same byte stream as the regular telnet console (CNSLPORT),\n"    \
+  "wrapped in RFC 6455 binary frames (websockify-style). The standard\n"        \
+  "telnet listener on CNSLPORT remains active and unaffected.\n"                \
+  "\n"                                                                          \
+  "Specify \"NO\" to disable the WebSocket listener. With no arguments,\n"      \
+  "displays the currently configured value. The port must differ from\n"        \
+  "CNSLPORT and (if set) SYSGPORT.\n"
+
+
 #define tf_cmd_desc             "Define trace-to-file parameters"
 #define tf_cmd_help             \
                                 \
@@ -2130,6 +2146,7 @@ COMMAND( "plant",                   stsi_plant_cmd,         SYSCFGNDIAG8,       
 COMMAND( "shcmdopt",                shcmdopt_cmd,           SYSCFGNDIAG8,       shcmdopt_cmd_desc,      shcmdopt_cmd_help   )
 COMMAND( "sysepoch",                sysepoch_cmd,           SYSCFGNDIAG8,       sysepoch_cmd_desc,      NULL                )
 COMMAND( "sysgport",                sysgport_cmd,           SYSCFGNDIAG8,       sysgport_cmd_desc,      NULL                )
+COMMAND( "wscnslport",              wscnslport_cmd,         SYSCFGNDIAG8,       wscnslport_cmd_desc,    wscnslport_cmd_help )
 COMMAND( "tzoffset",                tzoffset_cmd,           SYSCFGNDIAG8,       tzoffset_cmd_desc,      NULL                )
 COMMAND( "xpndsize",                xpndsize_cmd,           SYSCFGNDIAG8,       xpndsize_cmd_desc,      xpndsize_cmd_help   )
 COMMAND( "yroffset",                yroffset_cmd,           SYSCFGNDIAG8,       yroffset_cmd_desc,      NULL                )

--- a/console.c
+++ b/console.c
@@ -41,6 +41,7 @@
 #include "sr.h"
 #include "cnsllogo.h"
 #include "hexdumpe.h"
+#include "wscnsl.h"
 
 /*-------------------------------------------------------------------*/
 /*                 Tweakable build constants                         */
@@ -309,7 +310,7 @@ static void telnet_ev_handler( telnet_t* telnet, telnet_event_t* ev,
         CONDEBUG2( HHC90500, "D", tn->clientid, ev->data.size );
         DUMPBUF(   HHC90500, ev->data.buffer, ev->data.size, tn->do_tn3270 ? 1 : 0 );
 
-        if (write_socket( tn->csock, ev->data.buffer, ev->data.size ) <= 0)
+        if (ws_send( tn, ev->data.buffer, (int) ev->data.size ) <= 0)
         {
             tn->send_err = TRUE;
             // "%s COMM: send() failed: %s"
@@ -743,6 +744,7 @@ static void  disconnect_telnet_client( TELNET* tn )
     */
     if (tn)
     {
+        ws_free_state( tn );
         telnet_closesocket( tn->csock );
         telnet_free( tn->ctl );
 
@@ -2603,7 +2605,7 @@ BYTE    buf[ BUFLEN_3270 ];             /* Temporary recv() buffer   */
     dev->tn->overflow = FALSE;
 
     /* Read bytes from client */
-    rc = recv( dev->fd, buf, sizeof( buf ), 0 );
+    rc = ws_recv( dev->tn, buf, sizeof( buf ));
 
     /* Check for I/O error */
     if (rc < 0)
@@ -2775,7 +2777,7 @@ BYTE    buf[BUFLEN_1052];               /* Receive buffer            */
     dev->tn->overrun   = FALSE;
 
     /* Read bytes from client */
-    num = recv( dev->fd, buf, sizeof( buf ), 0 );
+    num = ws_recv( dev->tn, buf, sizeof( buf ));
 
     /* Return unit check if error on receive */
     if (num < 0)
@@ -2955,7 +2957,7 @@ size_t                  logoheight;     /* Logo file number of lines */
     do
     {
         /* Read client telnet negotiation data */
-        if ((rc = recv( csock, buf, sizeof( buf ), 0 )) > 0)
+        if ((rc = ws_recv( tn, buf, sizeof( buf ))) > 0)
         {
             // "%s COMM: received %d bytes"
             CONDEBUG2( HHC90501, "D", tn->clientid, rc );
@@ -3387,8 +3389,10 @@ static void* console_connection_handler( void* arg )
 int           rc = 0;                   /* Return code               */
 int           lsock;                    /* Console listening socket  */
 int           lsock2 = 0;               /* SYSG listening socket     */
+int           lsock_ws = 0;             /* WebSocket listening socket*/
 int           csock;                    /* Socket for conversation   */
 bool          sysg = false;             /* SYSG port connection      */
+bool          ws_conn = false;          /* WebSocket port connection */
 fd_set        readset;                  /* Read bit map for pselect  */
 int           maxfd;                    /* Highest fd for pselect    */
 int           scan_complete;            /* DEVBLK scan complete      */
@@ -3399,6 +3403,7 @@ BYTE          unitstat;                 /* Status after receive data */
 TELNET*       tn;                       /* Telnet Control Block      */
 const char*   curr_cnslport;            /* Current sysblk.cnslport   */
 const char*   curr_sysgport = NULL;     /* Current sysblk.sysgport   */
+const char*   curr_wscnslport = NULL;   /* Current sysblk.wscnslport */
 
 int prev_rlen3270;
 
@@ -3428,6 +3433,16 @@ int prev_rlen3270;
            and create starting listening socket */
         curr_sysgport = strdup( sysblk.sysgport );
         lsock2 = get_listening_socket( "SYSGPORT", "SYSG ", sysblk.sysgport );
+    }
+
+    if (sysblk.wscnslport)
+    {
+        /* Save starting sysblk.wscnslport value
+           and create starting listening socket */
+        curr_wscnslport = strdup( sysblk.wscnslport );
+        lsock_ws = get_listening_socket( "WSCNSLPORT", "WebSocket ",
+                                         sysblk.wscnslport );
+        if (lsock_ws < 0) lsock_ws = 0;
     }
 
     /* Handle connection requests and attention interrupts */
@@ -3460,6 +3475,27 @@ int prev_rlen3270;
             lsock2 = get_listening_socket( "SYSGPORT", "SYSG ", sysblk.sysgport );
         }
 
+        /* Did they enable, change or disable WSCNSLPORT? */
+        if (sysblk.wscnslport == NULL && curr_wscnslport != NULL)
+        {
+            /* User disabled the WebSocket listener via 'wscnslport NO' */
+            if (lsock_ws) close_socket( lsock_ws );
+            lsock_ws = 0;
+            free( curr_wscnslport );
+            curr_wscnslport = NULL;
+        }
+        else if (sysblk.wscnslport != NULL
+            && (curr_wscnslport == NULL
+                || strcmp( curr_wscnslport, sysblk.wscnslport ) != 0))
+        {
+            if (lsock_ws) close_socket( lsock_ws );
+            free( curr_wscnslport );
+            curr_wscnslport = strdup( sysblk.wscnslport );
+            lsock_ws = get_listening_socket( "WSCNSLPORT", "WebSocket ",
+                                             sysblk.wscnslport );
+            if (lsock_ws < 0) lsock_ws = 0;
+        }
+
         /* Initialize scan flags */
         scan_complete = TRUE;
         scan_retries = 0;
@@ -3478,6 +3514,14 @@ int prev_rlen3270;
             {
                 FD_SET( lsock2, &readset );     // (add SYSG port too)
                 maxfd = MAX( lsock, lsock2 );   // (then adjust maxfd)
+            }
+
+            /* If WSCNSLPORT defined, also watch the WebSocket port */
+            if (lsock_ws)
+            {
+                FD_SET( lsock_ws, &readset );
+                if (lsock_ws > maxfd)
+                    maxfd = lsock_ws;
             }
 
             SUPPORT_WAKEUP_CONSOLE_SELECT_VIA_PIPE( maxfd, &readset );
@@ -3640,12 +3684,21 @@ int prev_rlen3270;
 
         /* Accept incoming client connections */
         if (0
-            || (lsock2 && FD_ISSET( lsock2, &readset ))
+            || (lsock_ws && FD_ISSET( lsock_ws, &readset ))
+            || (lsock2   && FD_ISSET( lsock2,   &readset ))
             || FD_ISSET( lsock,  &readset )
         )
         {
             /* Accept a connection and create conversation socket */
-            if (lsock2 && FD_ISSET( lsock2, &readset ))
+            ws_conn = false;
+            sysg    = false;
+
+            if (lsock_ws && FD_ISSET( lsock_ws, &readset ))
+            {
+                csock = accept( lsock_ws, NULL, NULL );
+                ws_conn = true;
+            }
+            else if (lsock2 && FD_ISSET( lsock2, &readset ))
             {
                 csock = accept( lsock2, NULL, NULL );
                 sysg = true;
@@ -3653,7 +3706,6 @@ int prev_rlen3270;
             else
             {
                 csock = accept( lsock,  NULL, NULL );
-                sysg = false;
             }
 
             if (csock < 0)
@@ -3701,6 +3753,19 @@ int prev_rlen3270;
                 continue;
             }
 
+            /* If this is a WebSocket connection, perform the HTTP
+               Upgrade handshake before any telnet activity. The
+               handshake function logs failures and (when possible)
+               sends an HTTP error response back to the client. */
+            if (ws_conn)
+            {
+                if (ws_handshake( csock ) < 0)
+                {
+                    close_socket( csock );
+                    continue;
+                }
+            }
+
             /* Allocate Telnet Control Block for this client */
             if (!(tn = (TELNET*) calloc( 1, sizeof( TELNET ))))
             {
@@ -3711,9 +3776,14 @@ int prev_rlen3270;
             else
             {
                 static U32 clid = 0;
-                tn->csock = csock;
-                tn->sysg  = sysg;
+                tn->csock        = csock;
+                tn->sysg         = sysg;
+                tn->is_websocket = ws_conn ? 1 : 0;
                 MSGBUF( tn->clientid, "client %u", clid++ );
+
+                if (ws_conn)
+                    // "%s COMM: WebSocket handshake complete"
+                    WRMSG( HHC02919, "I", tn->clientid );
 
                 /* Initialize libtelnet package */
                 tn->ctl = telnet_init( telnet_opts,
@@ -3890,6 +3960,7 @@ int prev_rlen3270;
 
     free( curr_cnslport );
     free( curr_sysgport );
+    free( curr_wscnslport );
 
     /* Initialize scan flags */
     scan_complete = TRUE;
@@ -3960,7 +4031,8 @@ int prev_rlen3270;
 
     /* Close the listening sockets */
     close_socket( lsock  );
-    if (lsock2) close_socket( lsock2 );
+    if (lsock2)   close_socket( lsock2   );
+    if (lsock_ws) close_socket( lsock_ws );
 
     // "Thread id "TIDPAT", prio %2d, name %s ended"
     LOG_THREAD_END( CON_CONN_THREAD_NAME  );

--- a/hercules.cnf
+++ b/hercules.cnf
@@ -51,6 +51,7 @@
 
 # DEVTMAX      0                # Device threads, 8 on Windows, else unlimited
   CNSLPORT  3270                # TCP port number to which consoles connect
+  WSCNSLPORT 6080               # TCP port for browser-based WebSocket consoles
 # SHRDPORT  3990                # TCP port number for sharing DASD images
                                 # on this instance of Hercules (inactive)
 

--- a/hercules.cnf.rexx
+++ b/hercules.cnf.rexx
@@ -20,6 +20,7 @@ _PWD = directory()
 
 numcpu      =   1
 cnslport    =   3279
+wscnslport  =   6080
 
 Address HERCULES
 
@@ -60,6 +61,7 @@ NOECHO"timerint"     "1000"
 
 --  integrated Hercules I/O Controller
 NOECHO"cnslport"     cnslport
+NOECHO"wscnslport"   wscnslport
 
 -- message level
 NOECHO"msglevel"     "VERBOSE"

--- a/hsccmd.c
+++ b/hsccmd.c
@@ -4518,7 +4518,7 @@ int sysgport_cmd( int argc, char* argv[], char* cmdline )
 /*-------------------------------------------------------------------*/
 int wscnslport_cmd( int argc, char* argv[], char* cmdline )
 {
-    static char const* def_port = "3271";
+    static char const* def_port = "6080";
     bool disabled = false;
     int rc = 0;
     int i;

--- a/hsccmd.c
+++ b/hsccmd.c
@@ -4514,6 +4514,161 @@ int sysgport_cmd( int argc, char* argv[], char* cmdline )
 }
 
 /*-------------------------------------------------------------------*/
+/* wscnslport command - define WebSocket console port                */
+/*-------------------------------------------------------------------*/
+int wscnslport_cmd( int argc, char* argv[], char* cmdline )
+{
+    static char const* def_port = "3271";
+    bool disabled = false;
+    int rc = 0;
+    int i;
+
+    UNREFERENCED( cmdline );
+    UPPER_ARGV_0( argv );
+
+    if (argc > 2)
+    {
+        // "Invalid number of arguments for %s"
+        WRMSG( HHC01455, "E", argv[0] );
+        rc = -1;
+    }
+    else if (argc == 1) // Display current value
+    {
+        char buf[128];
+
+        if (sysblk.wscnslport && strchr( sysblk.wscnslport, ':' ) == NULL)
+        {
+            MSGBUF( buf, "on port %s", sysblk.wscnslport );
+        }
+        else // (!sysblk.wscnslport || host:port specified)
+        {
+            if (sysblk.wscnslport)
+            {
+                char* serv = NULL;
+                char* host = NULL;
+                char* port = NULL;
+
+                port = strdup( sysblk.wscnslport );
+
+                if ((serv = strchr( port, ':' )))
+                {
+                    *serv++ = '\0';
+
+                    if (*port)
+                        host = port;
+                }
+
+                MSGBUF( buf, "on port %s for host %s", serv, host );
+                free( port );
+            }
+        }
+
+        if (sysblk.wscnslport)
+        {
+            // "%s server %slistening %s"
+            WRMSG( HHC17001, "I", "WebSocket console", "", buf );
+        }
+        else
+        {
+            // "%s server %slistening %s"
+            WRMSG( HHC17001, "I", "WebSocket console", "NOT ", "on any port" );
+        }
+        rc = 0;
+    }
+    else // Set new value
+    {
+        if (str_caseless_eq( argv[1], "NO" ))
+        {
+            disabled = true;
+            rc = 1;
+        }
+        else
+        {
+            char* port;
+            char* host = strdup( argv[1] );
+
+            if ((port = strchr( host, ':' )) == NULL)
+                port = host;
+            else
+                *port++ = '\0';
+
+            for (i=0; i < (int) strlen( port ); i++)
+            {
+                if (!isdigit( (unsigned char)port[i] ))
+                {
+                    // "Invalid value %s specified for %s"
+                    WRMSG( HHC01451, "E", port, argv[0] );
+                    rc = -1;
+                    break;
+                }
+            }
+
+            if (rc != -1)  // (if no parsing error)
+            {
+                i = atoi( port );
+
+                if (i < 0 || i > 65535)
+                {
+                    // "Invalid value %s specified for %s"
+                    WRMSG( HHC01451, "E", port, argv[0] );
+                    rc = -1;
+                }
+                else
+                    rc = 1;
+            }
+
+            free( host );
+        }
+    }
+
+    if (rc != 0) // (new value specified or error)
+    {
+        const char* port = (rc == -1) ? def_port : argv[1];
+
+        if (!disabled && str_eq( port, sysblk.cnslport ))
+        {
+            // "%s cannot be the same as %s"
+            WRMSG( HHC01453, "E", argv[0], "CNSLPORT" );
+            rc = -1;
+        }
+        else if (!disabled && sysblk.sysgport && str_eq( port, sysblk.sysgport ))
+        {
+            // "%s cannot be the same as %s"
+            WRMSG( HHC01453, "E", argv[0], "SYSGPORT" );
+            rc = -1;
+        }
+        else // (disabled || port okay)
+        {
+            free( sysblk.wscnslport );
+            sysblk.wscnslport = NULL;
+
+            if (!disabled && rc == -1)
+            {
+                // "Default port %s being used for %s"
+                WRMSG( HHC01452, "W", def_port, argv[0] );
+                sysblk.wscnslport = strdup( def_port );
+                rc = 1;
+            }
+            else // (disabled || rc != -1)
+            {
+                if (!disabled)
+                    sysblk.wscnslport = strdup( argv[1] );
+
+                // "%-14s set to %s"
+                WRMSG( HHC02204, "I", argv[0],
+                    disabled ? "NO" : sysblk.wscnslport );
+                rc = 0;
+            }
+        }
+    }
+
+    /* Wake the console connection thread so it picks up the new port. */
+    SIGNAL_CONSOLE_THREAD();
+
+    return rc;
+}
+
+/*-------------------------------------------------------------------*/
 /* http command - manage HTTP server                                 */
 /*-------------------------------------------------------------------*/
 int http_cmd(int argc, char *argv[], char *cmdline)

--- a/hstructs.h
+++ b/hstructs.h
@@ -1187,6 +1187,8 @@ atomic_update64( &sysblk.txf_stats[ contran ? 1 : 0 ].txf_ ## ctr, +1 )
 
         char    *cnslport;              /* console port string       */
         char    *sysgport;              /* SYSG console port string  */
+        char    *wscnslport;            /* WebSocket console port    */
+                                        /* (NULL = WS not enabled)   */
         char    **herclogo;             /* Constructed logo screen   */
         char    *logofile;              /* File name of logo file    */
         size_t  logolines;              /* Logo file number of lines */
@@ -1347,6 +1349,19 @@ struct TELNET {
         BYTE    send_err;               /* Socket send() failure     */
         BYTE    overflow;               /* Too much data accumulated */
         BYTE    overrun;                /* Unexpected extra data     */
+
+        /* ---- WebSocket bridge state (only used if is_websocket) ---- */
+        BYTE    is_websocket;           /* 1 = wrap I/O in WS frames */
+        BYTE    ws_close_sent;          /* 1 = WS Close frame sent   */
+        BYTE   *ws_inbuf;               /* Raw bytes from socket     */
+                                        /* (partial WS frames buffer)*/
+        size_t  ws_inbuf_size;          /* Allocated size of ws_inbuf*/
+        size_t  ws_inbuf_used;          /* Bytes currently held      */
+        BYTE   *ws_payload;             /* Decoded payload FIFO      */
+                                        /* (already-unmasked data    */
+                                        /*  ready for telnet_recv)   */
+        size_t  ws_payload_size;        /* Allocated size            */
+        size_t  ws_payload_used;        /* Bytes currently held      */
 };
 
 

--- a/html/hercconf.html
+++ b/html/hercconf.html
@@ -97,6 +97,7 @@ a real System/390.  The configuration file is an ASCII text file.
 
     <a href="#CODEPAGE">CODEPAGE</a>   819/1047
     <a href="#CNSLPORT">CNSLPORT</a>   3270             Listening port for 3270 device connections
+    <a href="#WSCNSLPORT">WSCNSLPORT</a> 6080             Listening port for WebSocket console connections
     <a href="#SYSGPORT">SYSGPORT</a>   3278             Listening port for SYSG device connections
     <a href="#CONKPALV">CONKPALV</a>   (3,1,10)
     <a href="#LEGACYSENSEID">LEGACYSENSEID</a>   OFF
@@ -1724,6 +1725,39 @@ a real System/390.  The configuration file is an ASCII text file.
     For timezones east of Greenwich, specify a positive value
     (example: <code>+0100</code> for Central European Time,
     <code>+0930</code> for South Australian Time).
+    <p>
+
+<a name="WSCNSLPORT"></a>
+<dt><code>WSCNSLPORT &nbsp; <i><u>6080</u></i> &nbsp;<i>-or-</i> &nbsp;<i>nnnn</i> &nbsp;<i>-or-</i> &nbsp;<i>host:port</i> &nbsp;<i>-or-</i> &nbsp;<code>NO</code></code>
+<dd><p>
+    Specifies the port number (in decimal) on which the WebSocket
+    console server should listen for incoming connections from
+    browser-based 3270 clients. If an invalid value is specified
+    Hercules defaults to port number <u>6080</u>.
+    Specifying <code>NO</code> disables the WebSocket console server.
+    <p>
+    The WebSocket console runs alongside the traditional telnet/tn3270
+    console controlled by <a href="#CNSLPORT"><code>CNSLPORT</code></a>;
+    it does <em>not</em> replace it. WebSocket clients use the same
+    3270 device pool, so the same restriction applies: no listening
+    port is opened unless at least one
+    <a href="#device_types_table">3270 device</a> is defined in your
+    configuration.
+    <p>
+    The <code>WSCNSLPORT</code> statement may also be specified as
+    <code>host:port</code>, where <code>host</code> identifies the
+    IP address of the host interface the WebSocket console server
+    should bind to. If not specified the server will accept
+    connections on the port from any host interface.
+    <p>
+    The chosen port must differ from
+    <a href="#CNSLPORT"><code>CNSLPORT</code></a> and
+    <a href="#SYSGPORT"><code>SYSGPORT</code></a>; valid range is
+    <code>0&ndash;65535</code>.
+    <p>
+    See the
+    <a href="../readme/README.WebSocket.md">WebSocket Console How-To</a>
+    for details on configuring and connecting browser-based clients.
     <p>
 
 <a name="XPNDSIZE"></a>

--- a/impl.c
+++ b/impl.c
@@ -1120,7 +1120,8 @@ int     rc;
     sysblk.sysgroup = DEFAULT_SYSGROUP;
 
     /* set default console port addresses */
-    sysblk.cnslport = strdup("3270");
+    sysblk.cnslport   = strdup("3270");
+    sysblk.wscnslport = NULL;       /* WebSocket console: opt-in only */
 
     /* Initialize automatic creation of missing tape file to default */
     sysblk.auto_tape_create = DEF_AUTO_TAPE_CREATE;

--- a/msgenu.h
+++ b/msgenu.h
@@ -2270,7 +2270,10 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp, bool quiet )
 #define HHC02915 "%s COMM: Connection received"
 #define HHC02916 "%s COMM: No acceptable terminal types"
 #define HHC02917 "COMM: Switching from %s polling"
-//efine HHC02918 - HHC02949 (available)
+#define HHC02918 "%s COMM: WebSocket handshake failed: %s"
+#define HHC02919 "%s COMM: WebSocket handshake complete"
+#define HHC02920 "%s COMM: WebSocket protocol error; closing connection"
+//efine HHC02921 - HHC02949 (available)
 
 // convto64
 #define HHC02950 "Usage: %s [-r] [-c] [-q] [-v] infile outfile"             "\n" \

--- a/msvc.makefile.includes/MOD_RULES2.msvc
+++ b/msvc.makefile.includes/MOD_RULES2.msvc
@@ -97,7 +97,7 @@ $(X)hdt3088.dll:  $(ctc_OBJ) $(tuntap_OBJ) \
     $(linkdll)
     $(MT_DLL_CMD)
 
-$(X)hdt3270.dll:  $(O)console.obj \
+$(X)hdt3270.dll:  $(O)console.obj $(O)wscnsl.obj \
                   $(O)hengine.lib $(O)hutil.lib $(O)hsys.lib $(O)hercprod.res
     $(linkdll)
     $(MT_DLL_CMD)

--- a/readme/README.WebSocket.md
+++ b/readme/README.WebSocket.md
@@ -97,8 +97,11 @@ will work. The handshake accepts any URL path, and no
 
 Examples of clients people have used in this pattern:
 
-- A browser-based 3270 emulator that speaks tn3270 over WebSocket
-  natively.
+- [**IronTerm**](https://github.com/bencz/IronTerm) &mdash; a
+  browser-based 3270 / 5250 web terminal that connects directly to a
+  Hercules `WSCNSLPORT` listener.
+- Any other browser-based 3270 emulator that speaks tn3270 over
+  WebSocket natively.
 - A traditional tn3270 client wrapped by `websocat`, `wstunnel`, or
   similar (see below).
 - A custom JavaScript client built around the tn3270 byte stream.

--- a/readme/README.WebSocket.md
+++ b/readme/README.WebSocket.md
@@ -1,0 +1,151 @@
+![header image](images/image_header_herculeshyperionSDL.png)
+[Return to master README.md](../README.md)
+
+# WebSocket Console Transport (`WSCNSLPORT`)
+
+1. [Introduction](#Introduction)
+2. [How it works](#How-it-works)
+3. [Configuration](#Configuration)
+4. [Runtime command](#Runtime-command)
+5. [Connecting a client](#Connecting-a-client)
+6. [Quick test with `websocat`](#Quick-test-with-websocat)
+7. [Constraints and caveats](#Constraints-and-caveats)
+8. [Bug reports](#Bug-reports)
+
+## Introduction
+
+The WebSocket console transport exposes Hercules' existing tn3270 / telnet
+console over an RFC 6455 WebSocket endpoint. It runs **alongside** the
+classic telnet console controlled by
+[`CNSLPORT`](../html/hercconf.html#CNSLPORT); it does not replace it.
+
+The intent is to let browser-based 3270 emulators (or any WebSocket-aware
+tn3270 client) connect to Hercules without requiring a local-machine
+telnet/tn3270 listener or a separate proxy such as `websockify`.
+
+## How it works
+
+The transport is implemented in `wscnsl.c` / `wscnsl.h` as a *websockify-style*
+bridge:
+
+- A new listener accepts plain TCP connections on the port configured by
+  `WSCNSLPORT`.
+- For each connection Hercules performs the standard HTTP/1.1 `Upgrade:
+  websocket` handshake (`Sec-WebSocket-Key` + `Sec-WebSocket-Accept`,
+  SHA-1 + RFC 4648 base64).
+- After the handshake the WebSocket payload is the **same byte stream**
+  the raw telnet socket would carry. Control frames (PING/PONG/CLOSE)
+  are handled internally; data frames (opcode `0x1` text or `0x2`
+  binary) are unmasked and fed to the existing libtelnet/3270 stack.
+- Hercules sends data back as unmasked **binary** frames (opcode
+  `0x2`, `FIN=1`).
+
+Because the payload is unchanged, every layer above the socket
+(`console.c`, `commadpt`, libtelnet, the 3270 device handler) is reused
+verbatim. The bridge introduces no new telnet negotiations.
+
+## Configuration
+
+Add a `WSCNSLPORT` statement to your `hercules.cnf` next to the existing
+`CNSLPORT` line:
+
+```
+CNSLPORT    3270             # Telnet / tn3270 listener (existing)
+WSCNSLPORT  6080             # WebSocket listener (new)
+```
+
+Accepted forms — see
+[`WSCNSLPORT` in hercconf.html](../html/hercconf.html#WSCNSLPORT):
+
+```
+WSCNSLPORT  6080                 # listen on 0.0.0.0:6080
+WSCNSLPORT  127.0.0.1:6080       # bind to a specific host interface
+WSCNSLPORT  NO                   # disable the WebSocket listener
+```
+
+Default port when an invalid value is supplied: **6080**.
+
+As with `CNSLPORT`, the listener is only opened when at least one
+[3270 device](../html/hercconf.html#device_types_table) is defined in
+the configuration.
+
+## Runtime command
+
+The same statement is available as a console command, both to inspect
+and to change the listener while Hercules is running:
+
+```
+wscnslport                   # show current value
+wscnslport 6080              # set port
+wscnslport 192.168.1.10:6080 # set host:port
+wscnslport NO                # disable
+```
+
+Changing the value signals the console connection thread so the
+listener is rebound without restarting Hercules.
+
+## Connecting a client
+
+The transport speaks **plain tn3270 over a binary WebSocket frame**, so
+any client capable of:
+
+1. Performing an RFC 6455 WebSocket handshake, and
+2. Speaking the tn3270 protocol on top of binary frames
+
+will work. The handshake accepts any URL path, and no
+`Sec-WebSocket-Protocol` subprotocol is negotiated.
+
+Examples of clients people have used in this pattern:
+
+- A browser-based 3270 emulator that speaks tn3270 over WebSocket
+  natively.
+- A traditional tn3270 client wrapped by `websocat`, `wstunnel`, or
+  similar (see below).
+- A custom JavaScript client built around the tn3270 byte stream.
+
+TLS is **not** terminated by Hercules; for `wss://` access put a
+reverse proxy (nginx, Caddy, HAProxy, ...) in front of the listener.
+
+## Quick test with `websocat`
+
+The simplest sanity check uses [`websocat`](https://github.com/vi/websocat)
+as a relay so a normal `telnet` / `x3270` client can talk to the
+WebSocket port:
+
+```
+# In one terminal — relay localhost:4000 -> ws://localhost:6080/
+websocat --binary -E tcp-l:127.0.0.1:4000 ws://127.0.0.1:6080/
+
+# In another terminal — connect a normal tn3270 client to the relay
+x3270 127.0.0.1:4000
+```
+
+If the connection reaches the Hercules logon screen, the WebSocket
+transport is working.
+
+## Constraints and caveats
+
+- `WSCNSLPORT` must differ from
+  [`CNSLPORT`](../html/hercconf.html#CNSLPORT) and
+  [`SYSGPORT`](../html/hercconf.html#SYSGPORT); attempting to reuse
+  either yields a configuration error.
+- Valid port range is `0`&ndash;`65535`. Invalid values fall back to
+  the default (`6080`) with a warning.
+- No TLS / `wss://` support in Hercules itself — front the port with a
+  reverse proxy if you need encryption.
+- No `Sec-WebSocket-Protocol` subprotocol value is required or
+  advertised; the URL path is ignored.
+- The WebSocket client shares the same 3270 device pool as the telnet
+  listener, so device-level limits (LU count, group restrictions,
+  etc.) apply identically.
+
+## Bug reports
+
+Please open issues at the SDL-Hercules-390 hyperion repository on
+GitHub, including:
+
+- The `WSCNSLPORT` statement (or `wscnslport` command output),
+- The relevant section of the Hercules log around the failed
+  handshake or disconnect, and
+- The exact client (`websocat`, browser emulator, etc.) and its
+  version.

--- a/wscnsl.c
+++ b/wscnsl.c
@@ -1,0 +1,752 @@
+/* WSCNSL.C    (C) Copyright Hercules contributors, 2026             */
+/*              WebSocket Console Bridge                              */
+/*                                                                   */
+/*   Released under "The Q Public License Version 1"                 */
+/*   (http://www.hercules-390.org/herclic.html) as modifications to  */
+/*   Hercules.                                                       */
+
+/*-------------------------------------------------------------------*/
+/* RFC 6455 WebSocket transport for the existing console pipeline.   */
+/*                                                                   */
+/* Architecture: the WebSocket carries the same bytes the raw telnet */
+/* socket would carry (websockify model). Per-connection state lives */
+/* on the TELNET struct (is_websocket flag + ws_inbuf / ws_payload   */
+/* buffers); the public API at the bottom of the file is the only    */
+/* surface the rest of console.c interacts with.                     */
+/*-------------------------------------------------------------------*/
+
+#include "hstdinc.h"
+#include "hercules.h"
+#include "hexterns.h"
+#include "wscnsl.h"
+
+/*-------------------------------------------------------------------*/
+/*  Self-contained SHA-1 (Steve Reid, 100% Public Domain)            */
+/*                                                                   */
+/*  Vendored locally so the WS bridge stays free of external runtime */
+/*  dependencies (the in-tree crypto/ library expects helper symbols */
+/*  that only dyncrypt.so exports, which would couple module load    */
+/*  order). This is the canonical 1995 reference implementation.    */
+/*-------------------------------------------------------------------*/
+
+#define WS_SHA1_DIGEST_LEN  20
+
+typedef struct {
+    U32   state[5];
+    U64   count;        /* total bits processed */
+    BYTE  buffer[64];
+} ws_sha1_ctx;
+
+#define WS_SHA1_ROL(v,b) (((v) << (b)) | ((v) >> (32 - (b))))
+
+#define WS_SHA1_BLK0(i)                                                       \
+    (block[i] = (((U32) buf[(i)*4    ]) << 24)                                \
+              | (((U32) buf[(i)*4 + 1]) << 16)                                \
+              | (((U32) buf[(i)*4 + 2]) <<  8)                                \
+              |  ((U32) buf[(i)*4 + 3]))
+#define WS_SHA1_BLK(i)                                                        \
+    (block[i & 15] = WS_SHA1_ROL(block[(i+13) & 15] ^ block[(i+8) & 15] ^     \
+                                 block[(i+ 2) & 15] ^ block[ i    & 15], 1))
+
+#define WS_SHA1_R0(v,w,x,y,z,i)                                               \
+    z += ((w & (x ^ y)) ^ y) + WS_SHA1_BLK0(i)  + 0x5A827999 + WS_SHA1_ROL(v,5); \
+    w  = WS_SHA1_ROL(w, 30);
+#define WS_SHA1_R1(v,w,x,y,z,i)                                               \
+    z += ((w & (x ^ y)) ^ y) + WS_SHA1_BLK(i)   + 0x5A827999 + WS_SHA1_ROL(v,5); \
+    w  = WS_SHA1_ROL(w, 30);
+#define WS_SHA1_R2(v,w,x,y,z,i)                                               \
+    z += (w ^ x ^ y)         + WS_SHA1_BLK(i)   + 0x6ED9EBA1 + WS_SHA1_ROL(v,5); \
+    w  = WS_SHA1_ROL(w, 30);
+#define WS_SHA1_R3(v,w,x,y,z,i)                                               \
+    z += (((w | x) & y) | (w & x)) + WS_SHA1_BLK(i) + 0x8F1BBCDC + WS_SHA1_ROL(v,5); \
+    w  = WS_SHA1_ROL(w, 30);
+#define WS_SHA1_R4(v,w,x,y,z,i)                                               \
+    z += (w ^ x ^ y)         + WS_SHA1_BLK(i)   + 0xCA62C1D6 + WS_SHA1_ROL(v,5); \
+    w  = WS_SHA1_ROL(w, 30);
+
+static void ws_sha1_transform( U32 state[5], const BYTE buf[64] )
+{
+    U32 a, b, c, d, e;
+    U32 block[16];
+
+    a = state[0]; b = state[1]; c = state[2]; d = state[3]; e = state[4];
+
+    WS_SHA1_R0(a,b,c,d,e, 0); WS_SHA1_R0(e,a,b,c,d, 1);
+    WS_SHA1_R0(d,e,a,b,c, 2); WS_SHA1_R0(c,d,e,a,b, 3);
+    WS_SHA1_R0(b,c,d,e,a, 4); WS_SHA1_R0(a,b,c,d,e, 5);
+    WS_SHA1_R0(e,a,b,c,d, 6); WS_SHA1_R0(d,e,a,b,c, 7);
+    WS_SHA1_R0(c,d,e,a,b, 8); WS_SHA1_R0(b,c,d,e,a, 9);
+    WS_SHA1_R0(a,b,c,d,e,10); WS_SHA1_R0(e,a,b,c,d,11);
+    WS_SHA1_R0(d,e,a,b,c,12); WS_SHA1_R0(c,d,e,a,b,13);
+    WS_SHA1_R0(b,c,d,e,a,14); WS_SHA1_R0(a,b,c,d,e,15);
+    WS_SHA1_R1(e,a,b,c,d,16); WS_SHA1_R1(d,e,a,b,c,17);
+    WS_SHA1_R1(c,d,e,a,b,18); WS_SHA1_R1(b,c,d,e,a,19);
+    WS_SHA1_R2(a,b,c,d,e,20); WS_SHA1_R2(e,a,b,c,d,21);
+    WS_SHA1_R2(d,e,a,b,c,22); WS_SHA1_R2(c,d,e,a,b,23);
+    WS_SHA1_R2(b,c,d,e,a,24); WS_SHA1_R2(a,b,c,d,e,25);
+    WS_SHA1_R2(e,a,b,c,d,26); WS_SHA1_R2(d,e,a,b,c,27);
+    WS_SHA1_R2(c,d,e,a,b,28); WS_SHA1_R2(b,c,d,e,a,29);
+    WS_SHA1_R2(a,b,c,d,e,30); WS_SHA1_R2(e,a,b,c,d,31);
+    WS_SHA1_R2(d,e,a,b,c,32); WS_SHA1_R2(c,d,e,a,b,33);
+    WS_SHA1_R2(b,c,d,e,a,34); WS_SHA1_R2(a,b,c,d,e,35);
+    WS_SHA1_R2(e,a,b,c,d,36); WS_SHA1_R2(d,e,a,b,c,37);
+    WS_SHA1_R2(c,d,e,a,b,38); WS_SHA1_R2(b,c,d,e,a,39);
+    WS_SHA1_R3(a,b,c,d,e,40); WS_SHA1_R3(e,a,b,c,d,41);
+    WS_SHA1_R3(d,e,a,b,c,42); WS_SHA1_R3(c,d,e,a,b,43);
+    WS_SHA1_R3(b,c,d,e,a,44); WS_SHA1_R3(a,b,c,d,e,45);
+    WS_SHA1_R3(e,a,b,c,d,46); WS_SHA1_R3(d,e,a,b,c,47);
+    WS_SHA1_R3(c,d,e,a,b,48); WS_SHA1_R3(b,c,d,e,a,49);
+    WS_SHA1_R3(a,b,c,d,e,50); WS_SHA1_R3(e,a,b,c,d,51);
+    WS_SHA1_R3(d,e,a,b,c,52); WS_SHA1_R3(c,d,e,a,b,53);
+    WS_SHA1_R3(b,c,d,e,a,54); WS_SHA1_R3(a,b,c,d,e,55);
+    WS_SHA1_R3(e,a,b,c,d,56); WS_SHA1_R3(d,e,a,b,c,57);
+    WS_SHA1_R3(c,d,e,a,b,58); WS_SHA1_R3(b,c,d,e,a,59);
+    WS_SHA1_R4(a,b,c,d,e,60); WS_SHA1_R4(e,a,b,c,d,61);
+    WS_SHA1_R4(d,e,a,b,c,62); WS_SHA1_R4(c,d,e,a,b,63);
+    WS_SHA1_R4(b,c,d,e,a,64); WS_SHA1_R4(a,b,c,d,e,65);
+    WS_SHA1_R4(e,a,b,c,d,66); WS_SHA1_R4(d,e,a,b,c,67);
+    WS_SHA1_R4(c,d,e,a,b,68); WS_SHA1_R4(b,c,d,e,a,69);
+    WS_SHA1_R4(a,b,c,d,e,70); WS_SHA1_R4(e,a,b,c,d,71);
+    WS_SHA1_R4(d,e,a,b,c,72); WS_SHA1_R4(c,d,e,a,b,73);
+    WS_SHA1_R4(b,c,d,e,a,74); WS_SHA1_R4(a,b,c,d,e,75);
+    WS_SHA1_R4(e,a,b,c,d,76); WS_SHA1_R4(d,e,a,b,c,77);
+    WS_SHA1_R4(c,d,e,a,b,78); WS_SHA1_R4(b,c,d,e,a,79);
+
+    state[0] += a; state[1] += b; state[2] += c;
+    state[3] += d; state[4] += e;
+}
+
+static void ws_sha1_init( ws_sha1_ctx* ctx )
+{
+    ctx->state[0] = 0x67452301;
+    ctx->state[1] = 0xEFCDAB89;
+    ctx->state[2] = 0x98BADCFE;
+    ctx->state[3] = 0x10325476;
+    ctx->state[4] = 0xC3D2E1F0;
+    ctx->count    = 0;
+}
+
+static void ws_sha1_update( ws_sha1_ctx* ctx, const BYTE* data, size_t len )
+{
+    size_t i = (size_t)((ctx->count >> 3) & 63);
+    size_t j;
+
+    ctx->count += (U64) len << 3;
+
+    if (i + len >= 64)
+    {
+        j = 64 - i;
+        memcpy( ctx->buffer + i, data, j );
+        ws_sha1_transform( ctx->state, ctx->buffer );
+        for (; j + 63 < len; j += 64)
+            ws_sha1_transform( ctx->state, data + j );
+        i = 0;
+    }
+    else
+        j = 0;
+
+    memcpy( ctx->buffer + i, data + j, len - j );
+}
+
+static void ws_sha1_final( BYTE digest[ WS_SHA1_DIGEST_LEN ], ws_sha1_ctx* ctx )
+{
+    BYTE finalcount[8];
+    BYTE c;
+    int  i;
+
+    for (i = 0; i < 8; i++)
+        finalcount[i] = (BYTE)((ctx->count >> ((7 - i) * 8)) & 0xFF);
+
+    c = 0x80;
+    ws_sha1_update( ctx, &c, 1 );
+    c = 0x00;
+    while ((ctx->count & 504) != 448)
+        ws_sha1_update( ctx, &c, 1 );
+    ws_sha1_update( ctx, finalcount, 8 );
+
+    for (i = 0; i < WS_SHA1_DIGEST_LEN; i++)
+        digest[i] = (BYTE)((ctx->state[i >> 2] >> ((3 - (i & 3)) * 8)) & 0xFF);
+
+    memset( ctx, 0, sizeof( *ctx ));
+}
+
+/*-------------------------------------------------------------------*/
+/*                  Tweakable build constants                        */
+/*-------------------------------------------------------------------*/
+#define WS_HANDSHAKE_BUFLEN     8192        /* Max HTTP request size */
+#define WS_INBUF_INIT           4096        /* Initial recv scratch  */
+#define WS_INBUF_MAX            (1 << 20)   /* Hard cap (1 MiB)      */
+#define WS_PAYLOAD_INIT         4096        /* Initial payload FIFO  */
+#define WS_PAYLOAD_MAX          (1 << 20)   /* Hard cap (1 MiB)      */
+#define WS_GUID                 "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+/* RFC 6455 opcodes */
+#define WS_OP_CONT              0x0
+#define WS_OP_TEXT              0x1
+#define WS_OP_BINARY            0x2
+#define WS_OP_CLOSE             0x8
+#define WS_OP_PING              0x9
+#define WS_OP_PONG              0xA
+
+/*-------------------------------------------------------------------*/
+/*                      Base64 (encode-only)                         */
+/*-------------------------------------------------------------------*/
+static const char b64_alphabet[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* Encode 'len' bytes into 'out' (caller-provided, must be >= 4*((len+2)/3)+1
+   bytes). Always null-terminates. Returns number of chars written
+   (excluding the null). */
+static size_t b64_encode( const BYTE* in, size_t len, char* out )
+{
+    size_t i = 0, o = 0;
+    while (i + 3 <= len)
+    {
+        U32 v = ((U32)in[i] << 16) | ((U32)in[i+1] << 8) | (U32)in[i+2];
+        out[o++] = b64_alphabet[(v >> 18) & 0x3F];
+        out[o++] = b64_alphabet[(v >> 12) & 0x3F];
+        out[o++] = b64_alphabet[(v >>  6) & 0x3F];
+        out[o++] = b64_alphabet[ v        & 0x3F];
+        i += 3;
+    }
+    if (i < len)
+    {
+        U32 v = (U32)in[i] << 16;
+        if (i + 1 < len) v |= (U32)in[i+1] << 8;
+        out[o++] = b64_alphabet[(v >> 18) & 0x3F];
+        out[o++] = b64_alphabet[(v >> 12) & 0x3F];
+        out[o++] = (i + 1 < len) ? b64_alphabet[(v >> 6) & 0x3F] : '=';
+        out[o++] = '=';
+    }
+    out[o] = '\0';
+    return o;
+}
+
+/*-------------------------------------------------------------------*/
+/*       Read HTTP request headers, terminating on CRLFCRLF          */
+/*-------------------------------------------------------------------*/
+/* Returns total bytes read on success, -1 on error. Buffer is null- */
+/* terminated. The caller's request arrives in one TCP burst from    */
+/* every browser/curl/wscat I've seen, but we still loop to be safe. */
+/*-------------------------------------------------------------------*/
+static int read_http_headers( int csock, char* buf, size_t bufsize )
+{
+    size_t total = 0;
+    int rc;
+
+    while (total + 1 < bufsize)
+    {
+        rc = recv( csock, buf + total, (int)(bufsize - 1 - total), 0 );
+        if (rc <= 0)
+            return -1;
+
+        total += rc;
+        buf[total] = '\0';
+
+        /* Look for end-of-headers marker */
+        if (total >= 4 && strstr( buf, "\r\n\r\n" ))
+            return (int) total;
+    }
+    /* Headers larger than our buffer -- bail */
+    return -1;
+}
+
+/*-------------------------------------------------------------------*/
+/*  Locate a header value (case-insensitive name match, RFC 7230)    */
+/*-------------------------------------------------------------------*/
+/* Returns malloc'd, trimmed value string or NULL if not found.      */
+/*-------------------------------------------------------------------*/
+static char* find_header_value( const char* headers, const char* name )
+{
+    size_t namelen = strlen( name );
+    const char* p = headers;
+    const char* eol;
+    const char* val;
+    const char* end;
+    char* out;
+    size_t vallen;
+
+    /* Skip request line */
+    eol = strstr( p, "\r\n" );
+    if (!eol)
+        return NULL;
+    p = eol + 2;
+
+    while (*p && p[0] != '\r')
+    {
+        eol = strstr( p, "\r\n" );
+        if (!eol)
+            return NULL;
+
+        if ((size_t)(eol - p) > namelen
+            && strncasecmp( p, name, namelen ) == 0
+            && p[namelen] == ':')
+        {
+            val = p + namelen + 1;
+            while (val < eol && (*val == ' ' || *val == '\t'))
+                val++;
+            end = eol;
+            while (end > val && (end[-1] == ' ' || end[-1] == '\t'))
+                end--;
+
+            vallen = (size_t)(end - val);
+            out = (char*) malloc( vallen + 1 );
+            if (!out) return NULL;
+            memcpy( out, val, vallen );
+            out[vallen] = '\0';
+            return out;
+        }
+        p = eol + 2;
+    }
+    return NULL;
+}
+
+/*-------------------------------------------------------------------*/
+/*           Compute Sec-WebSocket-Accept response value             */
+/*-------------------------------------------------------------------*/
+static void compute_accept_key( const char* client_key, char* accept_out )
+{
+    ws_sha1_ctx ctx;
+    BYTE digest[ WS_SHA1_DIGEST_LEN ];
+
+    ws_sha1_init( &ctx );
+    ws_sha1_update( &ctx, (const BYTE*) client_key, strlen( client_key ));
+    ws_sha1_update( &ctx, (const BYTE*) WS_GUID,    sizeof( WS_GUID ) - 1 );
+    ws_sha1_final( digest, &ctx );
+
+    b64_encode( digest, WS_SHA1_DIGEST_LEN, accept_out );
+}
+
+/*-------------------------------------------------------------------*/
+/*       Send a small HTTP error response and close the socket       */
+/*-------------------------------------------------------------------*/
+static void send_http_error( int csock, const char* status_line )
+{
+    char resp[256];
+    int n = snprintf( resp, sizeof( resp ),
+        "HTTP/1.1 %s\r\n"
+        "Content-Length: 0\r\n"
+        "Connection: close\r\n"
+        "\r\n", status_line );
+    if (n > 0)
+        write_socket( csock, resp, n );
+}
+
+/*-------------------------------------------------------------------*/
+/*                  ws_handshake (public API)                        */
+/*-------------------------------------------------------------------*/
+int ws_handshake( int csock )
+{
+    char    headers [ WS_HANDSHAKE_BUFLEN ];
+    char    accept_key [ 64 ];
+    char    response   [ 512 ];
+    char*   key   = NULL;
+    char*   upgrade = NULL;
+    int     rc;
+    int     n;
+
+    rc = read_http_headers( csock, headers, sizeof( headers ));
+    if (rc < 0)
+    {
+        // "%s COMM: WebSocket handshake failed: %s"
+        WRMSG( HHC02918, "E", "client", "could not read HTTP request" );
+        return -1;
+    }
+
+    /* Sanity: must be a GET request */
+    if (strncmp( headers, "GET ", 4 ) != 0)
+    {
+        send_http_error( csock, "405 Method Not Allowed" );
+        return -1;
+    }
+
+    /* Must have "Upgrade: websocket" header */
+    upgrade = find_header_value( headers, "Upgrade" );
+    if (!upgrade || strcasecmp( upgrade, "websocket" ) != 0)
+    {
+        free( upgrade );
+        send_http_error( csock, "400 Bad Request" );
+        return -1;
+    }
+    free( upgrade );
+
+    /* Sec-WebSocket-Key is mandatory */
+    key = find_header_value( headers, "Sec-WebSocket-Key" );
+    if (!key || strlen( key ) == 0)
+    {
+        free( key );
+        send_http_error( csock, "400 Bad Request" );
+        return -1;
+    }
+
+    compute_accept_key( key, accept_key );
+    free( key );
+
+    n = snprintf( response, sizeof( response ),
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Accept: %s\r\n"
+        "\r\n",
+        accept_key );
+
+    if (n <= 0 || n >= (int) sizeof( response ))
+        return -1;
+
+    if (write_socket( csock, response, n ) != n)
+        return -1;
+
+    return 0;
+}
+
+/*-------------------------------------------------------------------*/
+/*                Buffer growth helpers (FIFO byte queues)           */
+/*-------------------------------------------------------------------*/
+/* Ensure buf has room for 'extra' more bytes (after the existing    */
+/* 'used' bytes). Returns 0 on success, -1 on cap-exceeded.          */
+/*-------------------------------------------------------------------*/
+static int ensure_buf( BYTE** buf, size_t* size, size_t used,
+                       size_t extra, size_t cap )
+{
+    size_t need = used + extra;
+    size_t newsz;
+
+    if (need <= *size)
+        return 0;
+    if (need > cap)
+        return -1;
+
+    newsz = *size ? *size : 64;
+    while (newsz < need)
+        newsz <<= 1;
+    if (newsz > cap)
+        newsz = cap;
+
+    {
+        BYTE* p = (BYTE*) realloc( *buf, newsz );
+        if (!p) return -1;
+        *buf  = p;
+        *size = newsz;
+    }
+    return 0;
+}
+
+/* Drop the first 'n' bytes from a FIFO byte queue. */
+static void drop_prefix( BYTE* buf, size_t* used, size_t n )
+{
+    if (n >= *used)
+    {
+        *used = 0;
+        return;
+    }
+    memmove( buf, buf + n, *used - n );
+    *used -= n;
+}
+
+/*-------------------------------------------------------------------*/
+/*               Build and send a single WS frame                    */
+/*-------------------------------------------------------------------*/
+/* Server frames are unmasked. Returns 0 on success, -1 on error.    */
+/*-------------------------------------------------------------------*/
+static int ws_send_frame( int csock, BYTE opcode,
+                          const void* payload, size_t len )
+{
+    BYTE   hdr[ 14 ];           /* max header size (no mask) */
+    size_t hdrlen = 0;
+    BYTE*  out;
+    int    rc;
+    int    total;
+
+    hdr[0] = 0x80 | (opcode & 0x0F);    /* FIN=1 */
+
+    if (len < 126)
+    {
+        hdr[1] = (BYTE) len;
+        hdrlen = 2;
+    }
+    else if (len < 65536)
+    {
+        hdr[1] = 126;
+        hdr[2] = (BYTE)((len >> 8) & 0xFF);
+        hdr[3] = (BYTE)( len       & 0xFF);
+        hdrlen = 4;
+    }
+    else
+    {
+        U64 l64 = (U64) len;
+        hdr[1]  = 127;
+        hdr[2]  = (BYTE)((l64 >> 56) & 0xFF);
+        hdr[3]  = (BYTE)((l64 >> 48) & 0xFF);
+        hdr[4]  = (BYTE)((l64 >> 40) & 0xFF);
+        hdr[5]  = (BYTE)((l64 >> 32) & 0xFF);
+        hdr[6]  = (BYTE)((l64 >> 24) & 0xFF);
+        hdr[7]  = (BYTE)((l64 >> 16) & 0xFF);
+        hdr[8]  = (BYTE)((l64 >>  8) & 0xFF);
+        hdr[9]  = (BYTE)( l64        & 0xFF);
+        hdrlen = 10;
+    }
+
+    /* One contiguous write avoids the risk of a partial-frame on the
+       wire if the second write_socket happened to fail mid-stream. */
+    total = (int)(hdrlen + len);
+    out = (BYTE*) malloc( total );
+    if (!out)
+        return -1;
+    memcpy( out, hdr, hdrlen );
+    if (len)
+        memcpy( out + hdrlen, payload, len );
+
+    rc = write_socket( csock, out, total );
+    free( out );
+
+    return (rc == total) ? 0 : -1;
+}
+
+/*-------------------------------------------------------------------*/
+/*  Try to parse one frame off tn->ws_inbuf into tn->ws_payload      */
+/*-------------------------------------------------------------------*/
+/* Returns: 1 = a frame was consumed (more may remain);              */
+/*          0 = need more bytes;                                     */
+/*         -1 = protocol error / connection should close.            */
+/*-------------------------------------------------------------------*/
+static int parse_one_frame( TELNET* tn )
+{
+    BYTE*  in    = tn->ws_inbuf;
+    size_t avail = tn->ws_inbuf_used;
+    BYTE   b0, b1, opcode;
+    int    masked;
+    U64    payload_len;
+    size_t hdrlen;
+    BYTE   mask[4];
+    size_t i;
+
+    if (avail < 2)
+        return 0;
+
+    b0      = in[0];
+    b1      = in[1];
+    opcode  = b0 & 0x0F;
+    masked  = (b1 & 0x80) ? 1 : 0;
+    payload_len = b1 & 0x7F;
+    hdrlen  = 2;
+
+    if (payload_len == 126)
+    {
+        if (avail < 4) return 0;
+        payload_len = ((U64) in[2] << 8) | (U64) in[3];
+        hdrlen = 4;
+    }
+    else if (payload_len == 127)
+    {
+        if (avail < 10) return 0;
+        payload_len =
+              ((U64) in[2] << 56)
+            | ((U64) in[3] << 48)
+            | ((U64) in[4] << 40)
+            | ((U64) in[5] << 32)
+            | ((U64) in[6] << 24)
+            | ((U64) in[7] << 16)
+            | ((U64) in[8] <<  8)
+            | ((U64) in[9]      );
+        hdrlen = 10;
+    }
+
+    /* RFC 6455: client→server frames MUST be masked */
+    if (!masked)
+        return -1;
+
+    if (avail < hdrlen + 4)
+        return 0;
+    memcpy( mask, in + hdrlen, 4 );
+    hdrlen += 4;
+
+    /* Reject payloads that don't fit our cap */
+    if (payload_len > (U64) WS_PAYLOAD_MAX)
+        return -1;
+
+    if (avail < hdrlen + payload_len)
+        return 0;
+
+    /* Full frame is here. Process by opcode. */
+    switch (opcode)
+    {
+        case WS_OP_CONT:
+        case WS_OP_TEXT:
+        case WS_OP_BINARY:
+        {
+            if (ensure_buf( &tn->ws_payload, &tn->ws_payload_size,
+                            tn->ws_payload_used, (size_t) payload_len,
+                            WS_PAYLOAD_MAX ) != 0)
+                return -1;
+
+            /* Unmask payload directly into ws_payload tail */
+            for (i = 0; i < (size_t) payload_len; i++)
+            {
+                tn->ws_payload[ tn->ws_payload_used + i ] =
+                    in[ hdrlen + i ] ^ mask[ i & 3 ];
+            }
+            tn->ws_payload_used += (size_t) payload_len;
+            break;
+        }
+
+        case WS_OP_PING:
+        {
+            /* Echo back as PONG with same (unmasked) payload */
+            BYTE small[125];
+            BYTE* tmp = NULL;
+            BYTE* payload = NULL;
+            int   rc;
+
+            if (payload_len <= sizeof( small ))
+                payload = small;
+            else
+            {
+                tmp = (BYTE*) malloc( (size_t) payload_len );
+                if (!tmp) return -1;
+                payload = tmp;
+            }
+            for (i = 0; i < (size_t) payload_len; i++)
+                payload[i] = in[ hdrlen + i ] ^ mask[ i & 3 ];
+
+            rc = ws_send_frame( tn->csock, WS_OP_PONG,
+                                payload, (size_t) payload_len );
+            if (tmp) free( tmp );
+            if (rc < 0) return -1;
+            break;
+        }
+
+        case WS_OP_PONG:
+            /* Unsolicited pong: discard */
+            break;
+
+        case WS_OP_CLOSE:
+            /* Reply with close (echo the same code if present) and
+               signal end-of-stream to the caller. */
+            if (!tn->ws_close_sent)
+            {
+                BYTE close_pl[125];
+                size_t close_len = 0;
+                if (payload_len >= 2 && payload_len <= sizeof( close_pl ))
+                {
+                    for (i = 0; i < (size_t) payload_len; i++)
+                        close_pl[i] = in[ hdrlen + i ] ^ mask[ i & 3 ];
+                    close_len = (size_t) payload_len;
+                }
+                ws_send_frame( tn->csock, WS_OP_CLOSE, close_pl, close_len );
+                tn->ws_close_sent = 1;
+            }
+            return -1;          /* Treat as connection closed */
+
+        default:
+            /* Reserved / unknown opcode */
+            return -1;
+    }
+
+    /* Drop this frame's bytes from the input buffer */
+    drop_prefix( tn->ws_inbuf, &tn->ws_inbuf_used, hdrlen + (size_t) payload_len );
+    return 1;
+}
+
+/*-------------------------------------------------------------------*/
+/* Drain as many complete frames as currently sit in ws_inbuf.       */
+/* Returns 0 on success, -1 on protocol error (caller should close). */
+/*-------------------------------------------------------------------*/
+static int parse_all_frames( TELNET* tn )
+{
+    int rc;
+    do {
+        rc = parse_one_frame( tn );
+        if (rc < 0) return -1;
+    } while (rc == 1);
+    return 0;
+}
+
+/*-------------------------------------------------------------------*/
+/*                  ws_recv (public API)                             */
+/*-------------------------------------------------------------------*/
+int ws_recv( TELNET* tn, void* buf, int nbytes )
+{
+    int   rc;
+    int   take;
+    BYTE  scratch[ 4096 ];
+
+    /* Plain socket: pass through */
+    if (!tn || !tn->is_websocket)
+        return recv( tn ? tn->csock : -1, buf, nbytes, 0 );
+
+    for (;;)
+    {
+        /* If we have buffered payload, deliver it first */
+        if (tn->ws_payload_used > 0)
+        {
+            take = (int) tn->ws_payload_used;
+            if (take > nbytes) take = nbytes;
+            memcpy( buf, tn->ws_payload, take );
+            drop_prefix( tn->ws_payload, &tn->ws_payload_used, take );
+            return take;
+        }
+
+        /* Otherwise, pull more bytes from the socket */
+        rc = recv( tn->csock, scratch, (int) sizeof( scratch ), 0 );
+        if (rc < 0)
+            return -1;          /* errno preserved (EAGAIN, etc.)    */
+        if (rc == 0)
+            return 0;           /* peer closed the connection        */
+
+        if (ensure_buf( &tn->ws_inbuf, &tn->ws_inbuf_size,
+                        tn->ws_inbuf_used, (size_t) rc,
+                        WS_INBUF_MAX ) != 0)
+            return -1;
+        memcpy( tn->ws_inbuf + tn->ws_inbuf_used, scratch, (size_t) rc );
+        tn->ws_inbuf_used += (size_t) rc;
+
+        if (parse_all_frames( tn ) < 0)
+            return -1;
+        /* loop: if the new bytes produced payload, next iteration
+           returns it; otherwise we recv() again. */
+    }
+}
+
+/*-------------------------------------------------------------------*/
+/*                  ws_send (public API)                             */
+/*-------------------------------------------------------------------*/
+int ws_send( TELNET* tn, const void* buf, int nbytes )
+{
+    if (!tn)
+        return -1;
+    if (!tn->is_websocket)
+        return write_socket( tn->csock, buf, nbytes );
+
+    if (nbytes <= 0)
+        return 0;
+
+    if (ws_send_frame( tn->csock, WS_OP_BINARY, buf, (size_t) nbytes ) < 0)
+        return -1;
+    return nbytes;
+}
+
+/*-------------------------------------------------------------------*/
+/*                  ws_free_state (public API)                       */
+/*-------------------------------------------------------------------*/
+void ws_free_state( TELNET* tn )
+{
+    if (!tn || !tn->is_websocket)
+        return;
+
+    if (!tn->ws_close_sent)
+    {
+        /* Best-effort close; ignore failures (peer may already be gone) */
+        ws_send_frame( tn->csock, WS_OP_CLOSE, NULL, 0 );
+        tn->ws_close_sent = 1;
+    }
+
+    if (tn->ws_inbuf)   free( tn->ws_inbuf );
+    if (tn->ws_payload) free( tn->ws_payload );
+    tn->ws_inbuf        = NULL;
+    tn->ws_payload      = NULL;
+    tn->ws_inbuf_size   = 0;
+    tn->ws_inbuf_used   = 0;
+    tn->ws_payload_size = 0;
+    tn->ws_payload_used = 0;
+    tn->is_websocket    = 0;
+}

--- a/wscnsl.h
+++ b/wscnsl.h
@@ -1,0 +1,53 @@
+/* WSCNSL.H    (C) Copyright Hercules contributors, 2026             */
+/*              WebSocket Console Bridge                              */
+/*                                                                   */
+/*   Released under "The Q Public License Version 1"                 */
+/*   (http://www.hercules-390.org/herclic.html) as modifications to  */
+/*   Hercules.                                                       */
+
+/*-------------------------------------------------------------------*/
+/* This module bridges the existing telnet/3270 console transport    */
+/* over WebSocket (RFC 6455) connections, websockify-style: the WS   */
+/* payload is the same byte stream the raw socket would carry, so    */
+/* the libtelnet/3270 stack above is unchanged.                      */
+/*-------------------------------------------------------------------*/
+
+#ifndef _WSCNSL_H_
+#define _WSCNSL_H_
+
+#include "hercules.h"
+
+/*-------------------------------------------------------------------*/
+/* Perform the HTTP Upgrade handshake on a freshly accepted socket.  */
+/* Returns 0 on success, -1 on failure (and writes an HTTP 4xx       */
+/* response to the client when possible).                            */
+/*-------------------------------------------------------------------*/
+int  ws_handshake ( int csock );
+
+/*-------------------------------------------------------------------*/
+/* Drop-in replacement for recv() at the three console.c read sites. */
+/* For non-WebSocket connections (tn->is_websocket == 0) it simply   */
+/* calls recv() on tn->csock. For WebSocket connections it parses    */
+/* RFC 6455 frames, transparently handles control frames (PING/PONG/ */
+/* CLOSE), unmasks payload bytes and returns them to the caller.     */
+/* Same return semantics as recv(): >0 = bytes, 0 = EOF, -1 = error. */
+/*-------------------------------------------------------------------*/
+int  ws_recv ( TELNET* tn, void* buf, int nbytes );
+
+/*-------------------------------------------------------------------*/
+/* Drop-in replacement for write_socket() in the TELNET_EV_SEND case.*/
+/* For non-WebSocket connections it calls write_socket() directly.   */
+/* For WebSocket connections it wraps the bytes in a binary frame    */
+/* (opcode 0x2, FIN=1, no mask) and writes the framed bytes.         */
+/* Returns total payload bytes accepted (>0) or <=0 on error.        */
+/*-------------------------------------------------------------------*/
+int  ws_send ( TELNET* tn, const void* buf, int nbytes );
+
+/*-------------------------------------------------------------------*/
+/* Tear down per-connection WebSocket state. Sends a Close frame to  */
+/* the peer if applicable, then frees the WS-only buffers. Caller is */
+/* still responsible for closing the underlying socket.              */
+/*-------------------------------------------------------------------*/
+void ws_free_state ( TELNET* tn );
+
+#endif /* _WSCNSL_H_ */


### PR DESCRIPTION
# Add WebSocket transport for the console

## Why

The 3270/telnet console is only reachable over raw TCP, which means a browser-based console has to go through an external bridge (websockify, a sidecar proxy, etc.). This adds a moving part to every deployment that wants a web UI, and the bridge has no idea about the device, so reconnect logic, port handling and lifecycle have to be duplicated outside Hercules.

This change lets a browser open a WebSocket directly to Hercules and talk to the same TN3270/1052 stack the telnet listener already serves.

## What

A new opt-in listener `WSCNSLPORT` runs in parallel with `CNSLPORT`. The wire format is RFC 6455 binary frames carrying the exact same bytes the raw socket would carry (the websockify model), so no client needs a custom protocol.

The integration surface in `console.c` is small: four I/O sites (one `write_socket`, three `recv`) now go through `ws_send` / `ws_recv` wrappers, and the `pselect` loop watches one extra listening socket. Telnet path is unchanged; if `WSCNSLPORT` is not set, nothing new is opened.

All WebSocket logic (handshake, frame codec, ping/pong/close handling, masked-payload unmasking) lives in `wscnsl.c`. SHA-1 is vendored inline (~120 lines, public domain) so `hdt3270.so` has zero new runtime dependencies.

## Files

- `wscnsl.{c,h}`: new
- `console.c`: wrap I/O sites, add WS listener to the accept loop
- `hstructs.h`: `wscnslport` in SYSBLK; WS state in TELNET
- `hsccmd.c` + `cmdtab.h`: `wscnslport` config/runtime command
- `impl.c`: default `wscnslport = NULL`
- `msgenu.h`: three new HHC02918/19/20 messages
- `Makefile.am` + four `Hercules_VS*.vcxproj`(`.filters`): build wiring

## Usage

```
# hercules.cnf
CNSLPORT     3270    # unchanged, telnet
WSCNSLPORT   3271    # new, opt-in
```

Or at runtime: `wscnslport 3271` / `wscnslport NO` / `wscnslport`.

## Tested

- Runtime: telnet console on 3270 still negotiates TN3270 fine; new WS listener on 3271 accepts connections, completes the HTTP Upgrade handshake, and frames the telnet stream both ways.
- Verified against MVS-TK5 with the bundled `mvs` launcher.

## Public tn3270-websocket for test:

A browser TN3270 client is hosted at **https://ironterm.bencz.cc/**.
It's a backend-less, build-step-free static page (source: [bencz/IronTerm](https://github.com/bencz/IronTerm)) that lets you exercise the new `WSCNSLPORT` listener end-to-end without writing any client code or running websockify.

## Screenshots

Tested on x3270 ( normal socket )
<img width="1036" height="770" alt="image" src="https://github.com/user-attachments/assets/5b62c455-7723-4a17-947a-ef6517bcbbea" />

Tested using webassembly
<img width="1059" height="791" alt="image" src="https://github.com/user-attachments/assets/7ecaa0a3-d333-4e88-af82-4102d2841c56" />
