### PR TITLE
Update System Log link in tasks.html

### DIFF
--- a/html/tasks.html
+++ b/html/tasks.html
@@ -7,7 +7,7 @@
 <center><img src="/images/hercpic-rblk-80.gif" alt="The Hercules System/370, ESA/390, and z/Architecture Emulator, (C) Copyright by Roger Bowler, Jan Jaeger, and others" title="The Hercules System/370, ESA/390, and z/Architecture Emulator, (C) Copyright by Roger Bowler, Jan Jaeger, and others" align=texttop></center>
 <hr width="100%">
 <h3>Tasks</h3>
-<a href="console.html" target="console">System Log</a><br>
+<a href="syslog.html" target="main">System Log</a><br>
 <a href="/cgi-bin/tasks/ipl" target="main">IPL</a><br>
 <hr width="100%">
 <h3>Debugging</h3>


### PR DESCRIPTION
Modified syslog link to only refesh sub frame -prevents unnecessary reload of fishgui.

Fixes error accidently introduced previously - only became visible once meter added as the reload of fishgui "flashed".