### PR TITLE
tcpip.c: never block the CPU thread in X'75' SEND

### DIFF
--- a/featall.h
+++ b/featall.h
@@ -50,6 +50,9 @@
                                         // ALWAYS at start SIE mode
 #define OPTION_NOASYNC_SF_CMDS          // Bypass bug in cache logic
                                         // (see GitHub Issue #618!)
+#define OPTION_USE_X75_NONE_BLOCKING_SEND   // Never block the CPU
+                                        // thread in X'75' SEND
+                                        // (see GitHub Issue #863!)
 
 /*-------------------------------------------------------------------*/
 /*              Normal default OPTIONs and FEATUREs                  */

--- a/tcpip.c
+++ b/tcpip.c
@@ -511,6 +511,7 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
 
         if (check_not_sock (aux1, t)) return;
 
+#if defined( OPTION_USE_X75_NONE_BLOCKING_SEND )
         /* X'75' runs on the emulated CPU thread, so this send() must
            never block: a client that stops reading fills the host send
            buffer, a blocking send() would then freeze the CPU, and the
@@ -547,6 +548,15 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
             }
             return;
         }
+#else /* !OPTION_USE_X75_NONE_BLOCKING_SEND: original blocking send() */
+        if ((l = send (Ccom_han [aux1], t->buffer_in, t->len_in, 0)) == SOCKET_ERROR) {
+
+            Cerr [aux1] = Get_errno ();
+
+            t->ret_cd = -1;
+            return;
+        }
+#endif
 
         t->ret_cd = l;
         return;

--- a/tcpip.c
+++ b/tcpip.c
@@ -511,11 +511,40 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
 
         if (check_not_sock (aux1, t)) return;
 
-        if ((l = send (Ccom_han [aux1], t->buffer_in, t->len_in, 0)) == SOCKET_ERROR) {
+        /* X'75' runs on the emulated CPU thread, so this send() must
+           never block: a client that stops reading fills the host send
+           buffer, a blocking send() would then freeze the CPU, and the
+           Hercules watchdog reacts to a stalled CPU by crashing the whole
+           emulator.  Send without blocking and mirror the RECV/ACCEPT
+           contract -- a blocking guest socket is told to retry (-2), a
+           non-blocking one gets -1 with hEWOULDBLOCK. */
+#if defined( MSG_DONTWAIT )
+        l = send (Ccom_han [aux1], t->buffer_in, t->len_in, MSG_DONTWAIT);
+#else
+        timeout.tv_sec  = 0;
+        timeout.tv_usec = 0;
+        FD_ZERO (&sockets);
+        FD_SET (Ccom_han [aux1], &sockets);
+        if (select (Ccom_han [aux1] + 1, NULL, &sockets, NULL, &timeout) == 0) {
+            if (Ccom_blk [aux1]) {
+                t->ret_cd = -2;
+            } else {
+                Cerr [aux1] = hEWOULDBLOCK;
+                t->ret_cd = -1;
+            }
+            return;
+        }
+        l = send (Ccom_han [aux1], t->buffer_in, t->len_in, 0);
+#endif
+        if (l == SOCKET_ERROR) {
 
             Cerr [aux1] = Get_errno ();
 
-            t->ret_cd = -1;
+            if (Cerr [aux1] == hEWOULDBLOCK && Ccom_blk [aux1]) {
+                t->ret_cd = -2;   /* blocking socket: guest retries (mirrors RECV) */
+            } else {
+                t->ret_cd = -1;
+            }
             return;
         }
 


### PR DESCRIPTION
Addresses #863.

Offered as a starting point for discussion, not as the obviously-correct answer — the compatibility question at the end is one you are far better placed to judge than we are. If you would rather solve it differently, the issue stands on its own.

## The change

Make `SEND` (`tcpip.c`, `EZASOKET`, `case 10`) non-blocking and mirror the return contract the guest already gets from `RECV` and `ACCEPT`:

* blocking guest socket (`Ccom_blk` set, the default) → `-2`, "would block, retry"
* non-blocking guest socket → `-1` with `hEWOULDBLOCK`

`MSG_DONTWAIT` is used where available, with a zero-timeout `select()` on the write set as the fallback for platforms without it. The change is confined to `case 10`; nothing else in the file is touched.

## Design choice, and the alternatives

Returning `-2` for blocking sockets was chosen for consistency: it is the code `RECV` and `ACCEPT` have always returned in this situation, so a guest library that already cooperates with X'75' has somewhere to put the handling.

Two alternatives were considered and rejected, but you may weigh them differently:

1. **Always return `-1`/`EWOULDBLOCK`, regardless of `Ccom_blk`.** Simpler, but it reports a non-blocking condition on a socket the guest deliberately left blocking, which seems worse than asking it to retry.
2. **Retry inside Hercules until the send completes.** Most transparent for the guest, but any wait still occupies the CPU thread, which is the problem being fixed. Doing it properly would mean making X'75' interruptible and restartable — far more invasive than this, and it would need guidance from someone who knows that machinery better than we do.

## Downstream impact worth flagging

This makes a return code reachable that guests have never seen from `SEND`. On an unpatched emulator `SEND` returns only `-1` or a byte count, so any guest code path handling a full send buffer has been dead code until now.

We hit exactly that in our own stack after applying this change, in three separate places: an FTP server that treated the new return as fatal and aborted transfers, a REST module whose send loop advanced by the return value and so spun on a zero, and an HTTP server that had the handling but had never been able to exercise it. None of these are Hercules bugs — they are latent guest bugs that the blocking `send()` had been masking behind an emulator crash — but other users should expect to find similar spots, and "the emulator no longer dies, and now my guest misbehaves instead" is a confusing first impression if it arrives unannounced.

If that trade-off seems too sharp for a default, a configuration statement gating the behaviour would be easy to add — say the word.

## Testing

* Linux x86-64 (Debian 13, kernel 6.12), built from `develop`, guest MVS 3.8j under MVSCE, guest socket library using X'75' directly.
* Reproducer from #863: a client pipelining ~14 MB of HTTP responses onto one connection, then reading nothing for 40 s. Before the change this killed the emulator every time; after it, the emulator is unaffected, other guest work continues normally, and the guest server receives `EWOULDBLOCK` and closes the connection on its own.
* Regression pass over the workloads exercised before: normal request/response traffic, aborting clients, slow-but-reading clients — no change in behaviour.

Not tested by us, and worth a second pair of eyes:

* **Windows** — the `select()` fallback path is not compiled on our platform.
* **Other guest stacks.** We only exercise X'75' from our own socket library. A guest that ignores a `-2` from `SEND` will read it as a bogus byte count, so anyone with a different stack should check that path. Given that the contract appears to be undocumented, we would not assume other stacks handle it.