### PR TITLE
Fix infinite loop in ckd_read_count - Read Count Suffix Handling (z/VM Missing interrupts / HHC00418)

### DIFF
--- a/ckddasd.c
+++ b/ckddasd.c
@@ -1847,7 +1847,6 @@ char           *orient[] = {"none", "index", "count", "key", "data", "eot"};
         )
             break;
 
-        /*  ((( Something to do with LR/LRE Read Count Suffix?? )))  */
         if (1
             && IS_CCW_MTRACK( code )
             && (dev->ckdlaux & CKDLAUX_RDCNTSUF)
@@ -1863,13 +1862,18 @@ char           *orient[] = {"none", "index", "count", "key", "data", "eot"};
         {
             memcpy( rechdr, dev->ckdfcwrk, CKD_RECHDR_SIZE );
 
-            cyl  = fetch_hw( rechdr->cyl );
-            head = fetch_hw( rechdr->head );
+            dev->ckdcurrec = rechdr->rec;
+            dev->ckdcurkl  = rechdr->klen;
+            dev->ckdcurdl  = (rechdr->dlen[0] << 8) + rechdr->dlen[1];
+            dev->ckdrem    = 0;
 
-            if ((rc = ckd_seek( dev, cyl, head, NULL, unitstat )) < 0)
-                return -1;
+            if (dev->ckdcyls < 32768)
+                dev->ckdtrkof = (rechdr->cyl[0] == 0xFF) ? 0 : rechdr->cyl[0] >> 7;
+            else
+                dev->ckdtrkof = 0;
 
-            continue;
+            dev->ckdfcoun = 0;
+            break;
         }
 
         /* End of track found, so terminate with no record found


### PR DESCRIPTION
### Summary
A CPU bound infinite loop can occur within *ckd_read_count()* when a suffixed Read Count reaches the logical end of the track. The device thread will continuously spin inside the single CCW and never present an end status. This will cause z/VM's missing interrupt handler to detect the timeout and cancel the I/O. Producing the following informational log message:
```console
HCPMHT2153I DASD  0107 I/O CANCELLED DUE TO A MISSING INTERRUPT
```
The subsequent cancellation produces a race condition when the guest re-drives the I/O, where the newly created channel program races the orphaned spin loop against the same device block. Eventually validating stale track buffers and causing the following error:
```console
HHC00418E 0:0107 CKD file ./dasd/PALFP0.ckd: invalid track header for cyl 0 head 6 00 0E9C 0007
```
The spin loop has been recorded to pin an entire host core permanently (100% usage). 

Full console sequence:
```console
HCPMHT2153I DASD  0107 I/O CANCELLED DUE TO A MISSING INTERRUPT
HHC00418E 0:0107 CKD file ./dasd/PALFP0.ckd: invalid track header for cyl 0 head 6 00 0E9C 0007
HHC00007I Previous message from function 'ckd_dasd_read_track' at ckddasd.c(1095)
HCPERP517I  DASD  0107 AN OPERATION WAS TERMINATED BECAUSE AN  
HCPERP517I  UNRECOGNIZED ERROR OCCURRED 
HCPERP6303I SENSE = INVALID 
HCPERP6304I IRB = 00C24017 7FFD50D0 0C001F88 00800000  
HCPERP6305I USERID = SFSPAL   
HCPERP2216I CHANNEL PATH ID = 01
HCPMHT2153I DASD  0107 I/O CANCELLED DUE TO A MISSING INTERRUPT
HHC01315I 0:0107 CHAN: ccw DE24E000 7FFD5008=>00000001 7834A000 00000001 78348000 ................
HHC01312I 0:0107 CHAN: stat 0E00, count 0000
HHC01313I 0:0107 CHAN: sense 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
```
### Root Cause

The original code block that is shown in the git diff, was treating the saved count's record ID (CCHH) as if it were a physical track address. This is invalid for minidisks with non-zero origin since CMS writes minidisk-relative IDs while CP translates only the extents/seek addresses. 

In addition, the backward seek calls *ckd_seek()* directly, which bypasses the Define Extent check, thus after seeking it continues with every condition unchanged, so it reaches end of track and seeks back again forever - the target track contains onlu R0 and an end-of-track marker. If it had used the *mt_advance()* function, it would have enforced the Define Extent check, and ended the chain with a File Protected unit check, breaking the loop. 

### Reproduction
Under z/VM 7.4, login into a guest that accesses a minidisk starting at a nonzero real cylinder. In my testing, it was the starting of an SFS File Pool server accessing its volume on a minidisk. I also reproduced the error with a standard z/CMS guest that accesses two minidisks on a DASD volume where either minidisk does not start at real cylinder 0. 

### Fix
The fix entails returning the saved first count directly as the suffix Read Count's result. This is the proper behavior, reporting the wrap-around continuation point of a Read Any call.  Additionally,  remove the incorrect backward seek, that is done with the assumption of a record ID is a physical track address, restore orientation fields from the returned count as the normal decode path would, clear ckdfcoun so any unforeseen re-arrivals will terminate through the existing no-record-found path. 

The fix was validated on my z/VM 7.4 system. 

### Out of Scope
The race condition involving a cancelled channel program racing against re-driven channel program resulting in two concurrent chains on one device is a separate preexisting defect. This PR removes a discovered trigger, but not the race itself. In my opinion, the race condition fix is a larger scope that I would want to give the current maintainers and the community a chance to discuss the various ways to fix the issue, instead of simply implementing a fix my way. Let me know if that discussion is better suited as an issue, separate from this PR. 