### PR TITLE
tcpip.c: set SO_REUSEADDR on guest listening sockets

### DIFF
--- a/tcpip.c
+++ b/tcpip.c
@@ -348,6 +348,31 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
 
         if (check_not_sock (m, t)) return;
 
+        /* A guest server that restarts cannot ask for its listening address
+           to be re-usable itself: this interface has no SETSOCKOPT function
+           code, and adding one would only help guests built against it.
+           Without SO_REUSEADDR the host refuses the bind for as long as any
+           connection that was accepted on that port is still in TIME_WAIT,
+           which is what leaves a listening port unusable for a minute or
+           two after the guest program that owned it ended -- even after an
+           orderly shutdown that closed every socket.  So set it here, at
+           the one point every guest bind() passes through.
+
+           This does not let a guest bind over a port another socket is
+           actively LISTENing on, so a server can still tell that a previous
+           instance of itself is up and running.
+
+           Stream sockets only: on a datagram socket SO_REUSEADDR means
+           "share this port", which is not what anything here wants.  A
+           failure of either call is not fatal -- the bind below is what the
+           guest actually asked for. */
+        isock = sizeof (l);
+        if (getsockopt (Ccom_han [m], SOL_SOCKET, SO_TYPE, (char *)&l, &isock) == 0
+            && l == SOCK_STREAM) {
+            k = 1;
+            setsockopt (Ccom_han [m], SOL_SOCKET, SO_REUSEADDR, (const char *)&k, sizeof (k));
+        }
+
 #if defined(__APPLE__)
         bzero ((LPSOCKADDR)&Clocal_adx, sizeof (Clocal_adx)); /* cleanup address */
 #endif


### PR DESCRIPTION
Fixes #869.

After a guest server ends, its listening port stays unusable for a minute or two, and the next start of the same server fails its bind with `EADDRINUSE`. An orderly stop is enough to produce it — it does not need a crash, and every socket having been closed does not help.

The X'75' BIND function calls the host `bind()` with no socket options at all. A listening port cannot be re-bound while any connection that was accepted on it is still in `TIME_WAIT`, which is exactly the state a busy server leaves behind on the way out. Every host server sets `SO_REUSEADDR` for this reason; a guest server cannot. This interface has no SETSOCKOPT function code — the switch in `EZASOKET` runs from 1 to 19 and none of them sets socket options — and the guest library's dispatch vector has no entry for one either.

Observed on MVS 3.8j with an HTTP server, which carries two workarounds for it: it retries the bind on a configurable interval, and if that runs out it scans socket numbers looking for one still bound to its port so it can close it.

This sets the option in BIND, before the bind, at the one point every guest `bind()` passes through. Stream sockets only, checked with `SO_TYPE`: on a datagram socket `SO_REUSEADDR` means "share this port", which is not what anything here wants. Neither call is fatal on failure — the bind that follows is what the guest actually asked for.

### Deliberately unchanged

A guest still cannot bind over a port another socket is actively LISTENing on, so a server can still detect that a previous instance of itself is up and refuse to start twice.

### Not addressed here

A guest program that ends without closing its sockets — a hard abend with no recovery path — leaves the listening socket open on the host, and nothing binds over an active LISTEN. That needs the guest to clean up after itself and is a separate subject.

### Compatibility

No function code, no return code and no register usage changes, so the guest side of the interface is untouched in both directions: an existing guest module benefits without being rebuilt, and nothing new is required of guest code built after this. That is why this needs no build switch, unlike the non-blocking SEND change in #864, which made a new `-2` return reachable and had to be taught to the guest first.

### Verification

Compiles clean with gcc (Debian 13) and clang (macOS), no new warnings.

Running on MVS 3.8j since 2026-08-23 on a build carrying this change (`4.10.0.11738-SDL-DEV-g837f2f29`). Over ~31 hours of uptime the guest HTTP and FTP servers were started and stopped repeatedly — 137 listener starts on the HTTP port alone, including a burst of about 20 restarts inside 11 seconds. The emulator log contains no `EADDRINUSE` and no bind-retry message for the whole period; before the change, an immediate restart reliably reached the server's retry path.
