### PR TITLE
service.c: fix msglen tracking in gh534_fix

### DIFF
--- a/service.c
+++ b/service.c
@@ -224,8 +224,12 @@ static void gh534_fix( int msglen, BYTE* /*EBCDIC*/ e_msg )
         // end additional filters
 
         /* Find the start of the next control sequence */
-        if (!(p = memchr( p, ESC, msglen )))
+        if (!(p2 = memchr( p, ESC, msglen )))
             break; // (No control sequences remain! We're done!)
+
+        /* Adjust msglen for skipped bytes */
+        msglen -= (int)(p2 - p);
+        p = p2;
 
         /* If the next character is NOT a "parameter byte", then it's
            obviously not a CSI. It might be some other Linux escape


### PR DESCRIPTION
Pinging @JamesWekel since you have been updating this codepath recently.

I noticed this while running zLinux on my ARM64 machine (i.e., what looked like weird memory corruption). Valgrind subsequently reports an uninitialized-value read in memchr when cleaning up terminal escape sequences. If useful, I can provide the exact EBCDIC message that triggers the warning.

---

Adjust msglen when memchr advances to the next ESC, preventing subsequent scans and modifications from reading or writing beyond the remaining message.

Example valgrind output (from an x64 box validating the issue):

```
==296297== Thread 4 Processor CP00:
==296297== Conditional jump or move depends on uninitialised value(s)
==296297==    at 0x484C94F: memchr (vg_replace_strmem.c:986)
==296297==    by 0x4B9CF90: gh534_fix (service.c:227)
==296297==    by 0x4BA17E3: z900_service_call (service.c:2175)
==296297==    by 0x48FA217: z900_run_cpu (cpu.c:2135)
==296297==    by 0x48EF1CE: cpu_thread (cpu.c:2398)
==296297==    by 0x522A504: hthread_func (hthreads.c:1059)
```