### PR TITLE
tcpip.c: let SELECT state die with the socket it is keyed to

### DIFF
--- a/tcpip.c
+++ b/tcpip.c
@@ -637,6 +637,29 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
             Ccom_opn [aux1] = 0;
             Ccom_han [aux1] = -1;
             Ccom_blk [aux1] = 1;
+
+            /* The select state goes with the socket.  It is keyed by socket
+               number -- the guest hands in the highest socket of its set as
+               the handle -- so it belongs to a number rather than to the
+               task that is selecting, and the number is free for immediate
+               re-use the moment this returns.  Left behind, it outlives both
+               the socket and the address space that created it, and is
+               inherited by whichever unrelated task is handed that number
+               next.  A run that never reaches Finish -- its task cancelled,
+               or its socket closed under it -- leaks the state outright. */
+            if (Cselect [aux1] != NULL) {
+
+                free (Cselect [aux1]->ri);
+                free (Cselect [aux1]->wi);
+                free (Cselect [aux1]->ei);
+
+                free (Cselect [aux1]->ro);
+                free (Cselect [aux1]->wo);
+                free (Cselect [aux1]->eo);
+
+                free (Cselect [aux1]);
+                Cselect [aux1] = NULL;
+            }
         }
 
         t->ret_cd = 0;
@@ -731,6 +754,27 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
         m = func >> 16;
 
         if (check_not_sock (m, t)) return;
+
+        /* One guest select() is a run of subcodes, and every subcode but
+           Start works on the state Start created.  Now that CLOSE clears
+           that state, a run whose socket is closed under it finds nothing
+           left -- and so does a run on a socket number that has since been
+           handed to somebody else.  Fail the call rather than dereference
+           NULL.  Finish is left out: it copes with NULL by design, and the
+           guest issues it unconditionally at the end of every run.
+
+           This is not a new answer for the guest.  check_not_sock above
+           already returns -1 for every subcode once the socket is gone, so
+           existing guest code handles -1 from mid-select today; the only
+           change is that it now also arrives when the number was re-used,
+           where the run would otherwise continue on somebody else's state.
+           Only ret_cd is set, no Cerr [m], for the same reason
+           check_not_sock leaves it alone: the slot may not be ours. */
+        if (((aux1 & 0xFF) >= 1) && ((aux1 & 0xFF) <= 7) && (Cselect [m] == NULL)) {
+
+            t->ret_cd = -1;
+            return;
+        }
 
         switch (aux1 & 0xFF) {
         case 0:  /* Start */


### PR DESCRIPTION
Fixes #874.

Select state lives in `Cselect[]`, indexed by socket number -- the guest hands in the highest socket of its set as the handle -- so it belongs to a number rather than to the task that is selecting. `CLOSE` did not clear it, and the number is free for re-use the moment the socket closes. The state therefore outlives both the socket and the address space that created it, and is inherited by whichever unrelated task is handed that number next.

### Measured

A diagnostic build counting these events on a live MVS 3.8j system, in causal order:

```
17:22:49  IEF450I HTTPD HTTPD - ABEND S222        cancelled inside a select run on socket 2
17:23:28  CLOSE-W-STATE  sock=2   closewithstate=1
17:23:28  HTTPD027I CLOSING STALE SOCKET 2 ON PORT 8080
17:25:19  START-REUSE    sock=2   reuse=1
```

The run never reaches subcode 8, so the state is never freed. On restart the server's stale-socket sweep closes socket 2 and the emulator keeps the state. Two minutes later an unrelated FTP session is handed socket number 2 and inherits it, across address spaces.

Beyond the inheritance, the same keying gives a leak on every abnormal end of a selecting task, and a use after free whenever the number is re-assigned while the previous owner is still in its polling loop -- two runs then share one state object and whichever reaches subcode 8 first frees it under the other.

### The change

Free the state in `CLOSE`, and have subcodes 1 to 7 fail the call when there is no state rather than dereferencing NULL. Subcode 8 is left alone: it copes with NULL by design and the guest issues it unconditionally at the end of every run.

### Verified against the same reproducer

Rebuilt with the counters still in place plus this change, and the sequence repeated:

| | before | after |
|---|---|---|
| cancel during a select run | 17:22:49 | 18:07:42 |
| sweep closes the same seven sockets | 17:23:28 | 18:08:10 |
| `CLOSE-W-STATE` | fires | fires -- the event still occurs |
| `START-REUSE` | `reuse=1` after 2 minutes | **does not occur** |

Then sharpened: seven concurrent FTP sessions were opened, enough to claim the whole freed number range, each held long enough for select runs of its own. Before the change, one session was enough to trigger the inheritance. `nostate=0` throughout, so the new failure path was never taken and no guest was handed an unexpected return code.

Compiles clean with gcc (Debian 13) and clang (macOS), no new warnings.

### Compatibility

No function code, no return code and no register usage changes. `-1` from a subcode in mid-select is not new to the guest: `check_not_sock` already returns exactly that for every subcode once the socket is gone. The only change is that it also arrives when the number has been re-assigned in the meantime, where the run would otherwise carry on using state belonging to someone else. Existing guest modules therefore need no rebuild, and nothing new is required of guest code built after this -- which matters for this interface, where a guest application never knows which emulator version it will run under.

No build switch: nothing here alters what the guest can observe, and making a memory-lifetime defect selectable would only keep the broken path alive.

### Not in scope

The `nfds` this file passes to `select()` is derived from the handle of the highest socket *number* rather than the highest *handle*. That is a separate defect and is left untouched here: 40000 measured select runs on this system never had more than one descriptor in a set, so there is no evidence to restructure those subcodes on. It will be reported separately as a code finding.
