### PR TITLE
hstructs.h: unify bitfield packing behaviour

### DIFF
--- a/cckd.h
+++ b/cckd.h
@@ -402,11 +402,13 @@ struct CCKD_EXT {                       /* Ext for compressed ckd    */
                          updated:1,     /* 1=Update occurred         */
                          merging:1,     /* 1=File merge in progress  */
                          stopping:1,    /* 1=Device is closing       */
-                         notnull:1,     /* 1=Device has track images */
                          L2ok:1,        /* 1=All l2s below bounds    */
                          sfmerge:1,     /* 1=sf-xxxx merge           */
-                         sfforce:1,     /* 1=sf-xxxx force           */
-                         needsdh:1;     /* 1=written since last harden */
+                         sfforce:1;     /* 1=sf-xxxx force           */
+                                        /* Readahead Serialized      */
+        BYTE             notnull;       /* 1=Device has track images */
+                                        /* Writer Thread Serialized  */
+        BYTE             needsdh;       /* 1=written since last harden */
 
         int              sflevel;       /* sfk xxxx level            */
 

--- a/cckd64.h
+++ b/cckd64.h
@@ -153,11 +153,13 @@ struct CCKD64_EXT {                     /* Ext for compressed ckd    */
                          updated:1,     /* 1=Update occurred         */
                          merging:1,     /* 1=File merge in progress  */
                          stopping:1,    /* 1=Device is closing       */
-                         notnull:1,     /* 1=Device has track images */
                          L2ok:1,        /* 1=All l2s below bounds    */
                          sfmerge:1,     /* 1=sf-xxxx merge           */
-                         sfforce:1,     /* 1=sf-xxxx force           */
-                         needsdh:1;     /* 1=written since last harden */
+                         sfforce:1;     /* 1=sf-xxxx force           */
+                                        /* Readahead Serialized      */
+        BYTE             notnull;       /* 1=Device has track images */
+                                        /* Writer Thread Serialized  */
+        BYTE             needsdh;       /* 1=written since last harden */
 
         int              sflevel;       /* sfk xxxx level            */
 

--- a/hstructs.h
+++ b/hstructs.h
@@ -267,6 +267,7 @@ struct REGS {                           /* Processor registers       */
                 host:1,                 /* REGS are hostregs         */
                 guest:1,                /* REGS are guestregs        */
                 diagnose:1;             /* Diagnose instr executing  */
+        unsigned int:0;                 /* Move to next storage unit */
         unsigned int                    /* Flags (intlock serialized)*/
                 dummy:1,                /* 1=Dummy regs structure    */
                 configured:1,           /* 1=CPU is online           */
@@ -1571,7 +1572,7 @@ struct DEVBLK {                         /* Device configuration block*/
                 himdev:1,               /* 1=is a HIM device         */
                 debug:1,                /* 1=generic debug flag      */
                 reinit:1;               /* 1=devinit, not attach     */
-
+        unsigned int:0;                 /* Move to next storage unit */
         unsigned int                    /* Device state - serialized
                                             by dev->lock             */
                 busy:1,                 /* 1=Device is busy          */
@@ -1970,15 +1971,18 @@ struct DEVBLK {                         /* Device configuration block*/
         BYTE    ckdlcount;              /* Locate record count       */
         BYTE    ckdextcd;               /* extended code             */
         void   *cckd_ext;               /* -> CCKD_EXT, else NULL    */
-        /*
-         * #TODO: MSVC handles bit-field packing by aligning members to the
-         * boundary of their underlying type, inserting padding to ensure fields
-         * do not split across boundaries defined by the type size. Change to
-         * u_int when bumping HDL_VERS_DEVBLK.
-         */
         BYTE    cckd64:1;               /* 1=CCKD64/CFBA64           */
         BYTE    devcache:1;             /* 0 = device cache off
                                            1 = device cache on       */
+        /* 
+         * MSVC allocates bit-fields within storage units based on their
+         * underlying type, inserting padding when necessary to prevent a
+         * bit-field from crossing a boundary defined by that type.
+         *
+         * To match this behavior across compilers, use a zero-width field
+         * of the NEXT type to explicitly force the allocation boundary.
+         */
+        u_int   :0;                     /* Move to next storage unit */
         u_int   ckd3990:1;              /* 1=Control unit is 3990    */
         u_int   ckd3880:1;              /* 1=Control unit is 3880    */
         u_int   ckdxtdef:1;             /* 1=Define Extent processed */
@@ -2006,7 +2010,8 @@ struct DEVBLK {                         /* Device configuration block*/
         u_int   ckdUCnxt:1;             /* 1=CMDREJ next chained CCW     :AE: */
         u_int   ckdPostRSSD:1;          /* 1=Prev CCW was RSSD           :AE: */
         u_int   ckdPostSSM:1;           /* 1=Prev CCW was SSM            :AE: */
-        /* See #TODO above */
+        /* See comment above */
+        BYTE    :0;                     /* Force alignment to next byte */
         BYTE    ckdnvs:1;               /* 1=NVS defined             */
         BYTE    ckdraid:1;              /* 1=RAID device             */
         U16     ckdssdlen;              /* #of bytes of data prepared


### PR DESCRIPTION
This commit addresses two related issues with how compilers allocate and layout bit-fields within storage units:

## Underlying Types
[Example](https://github.com/SDL-Hercules-390/hyperion/blob/97130dbde8fe05ec3537b6dec39a3b288af995b0/hstructs.h#L1980-L1982):

```c
    BYTE    devcache:1;             /* 0 = device cache off
                                       1 = device cache on       */
    u_int   ckd3990:1;              /* 1=Control unit is 3990    */
```

MSVC allocates bit-fields within storage units based on their underlying type, inserting padding when necessary to prevent a bit-field from crossing a boundary defined by that type. Clang and GCC, however, can allocate bit-fields across underlying type boundaries rather than consistently starting each type at its natural boundary. See the provided godbolt example: https://godbolt.org/z/s3eWGb7qn

Given that these fields have been typed this way for many years, rather than changing the type of devcache to `u_int` to match the subsequent ckd flags, a zero-width bit-field of the NEXT type is used to explicitly force an allocation boundary (i.e., forcing GCC and clang to match MSVCs bit-field layout).

## Memory Locations
The C-standard defines a 'memory location' as:
```
    "either an object of scalar type, or a maximal sequence of adjacent
    bit-fields all having nonzero width"
```
Continuing:
```
    "Two threads of execution can update and access separate memory
    locations without interfering with each other."
```

Because the bit-fields (`execflag` through `sigp_ini_reset`) are adjacent and have nonzero width, the C standard considers the entire sequence to form a single 'memory location'. Therefore, to separate subsequent bit-fields, a zero-width bit-field must be declared to force the compiler to start a new allocation unit (and consequently a new 'memory location').

For instance, TSAN generates the following warning (line numbers omitted):
```
 Write of size 4 at 0x72c8000006a8 by thread T23 (mutexes: write M0):
   .0 deconfigure_cpu $(BUILD_DIR)/../config.c // ->configured = 0;
   .1 release_config $(BUILD_DIR)/../config.c
   .2 hdl_atexit $(BUILD_DIR)/../hdl.c
   .3 do_shutdown_now $(BUILD_DIR)/../hscmisc.c
   .4 do_shutdown $(BUILD_DIR)/../hscmisc.c

 Previous write of size 4 at 0x72c8000006a8 by thread T3:
   .0 z900_run_cpu $(BUILD_DIR)/../cpu.c // regs->execflag = 0;
   .1 cpu_thread $(BUILD_DIR)/../cpu.c
```

In practice this *should* mean very little since compilers will typically generate instructions to perform a bitwise AND of an 8-bit memory location with an 8-bit immediate value.

Clang 21.1.8:
```
  regs->execflag = 0;
    Assembly:
      80 A3 A8 06 00 00 FE    and     byte ptr [regs+6A8h], 0FEh
    Disassembly:
      *((_BYTE *)_RBX + 0x6A8) &= ~1u;

  sysblk.regs[ target_cpu ]->configured = 0;
    Assembly:
      41 80 A6 A9 06 00 00 F7 and     byte ptr [r14+6A9h], 0F7h
    Disassembly:
      *(_BYTE *)(v2 + 0x6A9) &= ~8u;
```

However, inspecting Hercules assembly generated by MSVC 14.51.36231:
```
  regs->execflag = 0;
    Assembly:
      81 A0 A8 06 00 00 FF F7 FF FF and     dword ptr [rax+6A8h], 0FFFFF7FFh
    Disassembly:
      *(_DWORD *)(... + 0x6A8) &= ~0x800u;

  sysblk.regs[ target_cpu ]->configured = 0;
    Assembly:
      83 A6 A8 06 00 00 FE          and     dword ptr [rsi+6A8h], 0FFFFFFFEh
    Disassembly:
      *(_DWORD *)(v4 + 0x6A8) &= ~1u;
```

Which shows that both bitops (a cpu thread only flag vs. a intlock serialized flag) are implemented as read-modify-write on the same memory location. Minifying the above into a Godbolt example: https://godbolt.org/z/Y8zqj57M5

## cckd.h

See the commit message.