### PR TITLE
Improve support for C11 compilation

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -635,6 +635,7 @@ DLL_EXPORT int ARCH_DEP( fix_program_interrupt_PSW )( REGS* regs )
 /* back to the run_cpu instruction execution loop to begin executing */
 /* instructions at the Program new PSW location.                     */
 /*-------------------------------------------------------------------*/
+CPU_INTERRUPT_IMPORT
 void (ATTR_REGPARM(2) ARCH_DEP( program_interrupt ))( REGS* regs, int pcode )
 {
 PSA    *psa;                            /* -> Prefixed storage area  */

--- a/hexterns.h
+++ b/hexterns.h
@@ -540,16 +540,11 @@ void z900_invalidate_tlbe( REGS* regs, BYTE* main );
 
 RADR apply_host_prefixing( REGS* regs, RADR raddr );
 
-#undef ATTRIBUTE_NORETURN
-#if defined(__GNUC__) && __GNUC__ >= 4
-    #define ATTRIBUTE_NORETURN __attribute__ ((__noreturn__))
-#else
-    #define ATTRIBUTE_NORETURN
-#endif
-
-CPU_DLL_IMPORT void (ATTR_REGPARM(2) s370_program_interrupt)( REGS* regs, int code ) ATTRIBUTE_NORETURN;
-CPU_DLL_IMPORT void (ATTR_REGPARM(2) s390_program_interrupt)( REGS* regs, int code ) ATTRIBUTE_NORETURN;
-CPU_DLL_IMPORT void (ATTR_REGPARM(2) z900_program_interrupt)( REGS* regs, int code ) ATTRIBUTE_NORETURN;
+#undef CPU_INTERRUPT_IMPORT
+#define CPU_INTERRUPT_IMPORT ATTR_NORETURN CPU_DLL_IMPORT
+CPU_INTERRUPT_IMPORT void (ATTR_REGPARM(2) s370_program_interrupt)( REGS* regs, int code );
+CPU_INTERRUPT_IMPORT void (ATTR_REGPARM(2) s390_program_interrupt)( REGS* regs, int code );
+CPU_INTERRUPT_IMPORT void (ATTR_REGPARM(2) z900_program_interrupt)( REGS* regs, int code );
 
 void s370_display_inst( REGS* iregs, BYTE* inst );
 void s390_display_inst( REGS* iregs, BYTE* inst );

--- a/hmacros.h
+++ b/hmacros.h
@@ -56,6 +56,22 @@
 #endif
 
 /*-------------------------------------------------------------------*/
+/*              Define NORETURN attributes by compiler               */
+/*-------------------------------------------------------------------*/
+
+#if !defined(ATTR_NORETURN)
+  #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    #define ATTR_NORETURN _Noreturn
+  #elif defined(__GNUC__) && __GNUC__ >= 4
+    #define ATTR_NORETURN __attribute__ ((__noreturn__))
+  #elif defined(_MSC_VER) && _MSC_VER >= 1200
+    #define ATTR_NORETURN __declspec(noreturn)
+  #else
+    #define ATTR_NORETURN /* noreturn */
+  #endif
+#endif
+
+/*-------------------------------------------------------------------*/
 /*         Round a value 'x' up to the next 'b' boundary             */
 /*-------------------------------------------------------------------*/
 #define ROUND_UP(x,b)       ((x)?((((x)+((b)-1))/(b))*(b)):(b))

--- a/hmalloc.h
+++ b/hmalloc.h
@@ -43,7 +43,9 @@
 
 #if !defined(CACHE_ALIGN)
 
-    #if defined(_MSC_VER) || defined(_MSVC_)
+    #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+        #define __ALIGN(_n)     _Alignas(_n)
+    #elif defined(_MSC_VER) || defined(_MSVC_)
         #define __ALIGN(_n)     __declspec(align(_n))
     #else
         #define __ALIGN(_n)     __attribute__ ((aligned(_n)))

--- a/httpserv.c
+++ b/httpserv.c
@@ -270,7 +270,7 @@ static time_t get_http_time(const char *date_str)
     char wkday[4], month_str[4], tz[4];
     int day, year, hour, min, sec;
     struct tm http_tm;
-    char *m;
+    const char *m;
     
     if (sscanf(date_str, "%3s, %d %3s %d %d:%d:%d %3s",
                wkday, &day, month_str, &year,

--- a/msgenu.h
+++ b/msgenu.h
@@ -216,7 +216,7 @@ LOGM_DLL_IMPORT int  panel_command_capture( char* cmd, char** resp, bool quiet )
 #define MSG( id, sev, ... )     #id "%s " id "\n", sev,           ## __VA_ARGS__
 #define MSG_C( id, sev, ... )   #id "%s " id "",   sev,           ## __VA_ARGS__
 
-#if defined( _MSVC_ ) && !defined(__clang__) // MS Windows
+#if defined( _MSVC_ ) && !defined(__clang__) && (!defined( _MSVC_TRADITIONAL ) || _MSVC_TRADITIONAL) // MS Windows
   #define EXTGUIMSG( ... )      send2gui(                         ## __VA_ARGS__ )
 #else // fucking linux
   #define EXTGUIMSG( ... )      send2gui(                            __VA_ARGS__ )


### PR DESCRIPTION
This PR contains a collection of changes related to C11 compilation.

The primary goal is to ensure successful compilation with MSVC when using `/Zc:preprocessor` (the _conforming_ preprocessor, enabled automatically by `/std:c11`), while also adding support for the C11 specifiers.