### PR TITLE
comm3705.c: fix lock-order inversion and use-after-free on close

### DIFF
--- a/comm3705.c
+++ b/comm3705.c
@@ -1100,6 +1100,7 @@ static void *telnet_thread(void *vca)
     int        sockopt;         /* Used for setsocketoption          */
     int rc;                     /* return code from various rtns     */
     struct sockaddr_in sin;     /* bind socket address structure     */
+    char threadname[40];        /* string for WRMSG                  */
     BYTE bfr[256];
 
     ca=(COMMADPT*)vca;
@@ -1107,13 +1108,14 @@ static void *telnet_thread(void *vca)
     ca->sfd = 0;
     devnum=ca->devnum;
 
+    MSGBUF(threadname, "3705 device(%1d:%04X) thread2", ca->dev->ssid, devnum);
+    LOG_THREAD_BEGIN( threadname );
+
     ca->lfd=socket(AF_INET,SOCK_STREAM,0);
     if(!socket_is_socket(ca->lfd))
     {
         WRMSG(HHC01002, "E",SSID_TO_LCSS(ca->dev->ssid),devnum,strerror(HSO_errno));
-        ca->have_cthread=0;
-        release_lock(&ca->lock);
-        return NULL;
+        goto telnet_thread_exit;
     }
 
     /* Reuse the address regardless of any */
@@ -1129,21 +1131,21 @@ static void *telnet_thread(void *vca)
     if (rc < 0)
     {
         WRMSG(HHC01000, "E",SSID_TO_LCSS(ca->dev->ssid),devnum,"bind()",strerror(HSO_errno));
-        return NULL;
+        goto telnet_thread_close;
     }
     /* Start the listen */
     rc = listen(ca->lfd,10);
     if (rc < 0)
     {
         WRMSG(HHC01000, "E",SSID_TO_LCSS(ca->dev->ssid),devnum,"listen()",strerror(HSO_errno));
-        return NULL;
+        goto telnet_thread_close;
     }
     WRMSG(HHC01004, "I", SSID_TO_LCSS(ca->dev->ssid), devnum, ca->lport);
     for (;;)
     {
         ca->sfd = 0;
         ca->sfd=accept(ca->lfd,NULL,0);
-        if (ca->sfd < 1)
+        if (ca->sfd < 0)
             continue;
         if  (connect_client(&ca->sfd))
         {
@@ -1189,10 +1191,17 @@ static void *telnet_thread(void *vca)
             commadpt_read_tty(ca,bfr,rc);
         }
         close_socket(ca->sfd);
-        ca->sfd = 0;
+        ca->sfd = -1;
     }
 
-    UNREACHABLE_CODE( return NULL );
+telnet_thread_close:
+    close_socket(ca->lfd);
+telnet_thread_exit:
+    ca->lfd = -1;
+    memset(&ca->tthread, 0, sizeof(TID));
+
+    LOG_THREAD_END( threadname );
+    return NULL;
 }
 
 /*-------------------------------------------------------------------*/
@@ -1211,36 +1220,43 @@ static void *commadpt_thread(void *vca)
     /* fetch the commadpt structure */
     ca=(COMMADPT *)vca;
 
-    /* Obtain the CA lock */
-    obtain_lock(&ca->lock);
-
     /* get a work copy of devnum (for messages) */
     devnum=ca->devnum;
 
     MSGBUF(threadname, "3705 device(%1d:%04X) thread", ca->dev->ssid, devnum);
     LOG_THREAD_BEGIN( threadname );
 
-    while (!sysblk.shutdown) {
-        release_lock(&ca->lock);
-        if(ca->ackspeed == 0) delay = 50000 + (ca->unack_attn_count * 100000);         /* Max's reliable algorithm      */
-        else delay = (ca->unack_attn_count * ca->unack_attn_count + 1) * ca->ackspeed; /* much faster but TCAM hates it */
-        USLEEP(min((int)(ONE_MILLION-1),delay));                                       /* go to sleep, max. 1 second    */
+    while (TRUE) {
+        int unack_attn_count;
         obtain_lock(&ca->lock);
+        if (ca->haltpending) /* Check for exit */
+            break;
+
         make_sna_requests2(ca);
         make_sna_requests3(ca);
+        unack_attn_count = ca->unack_attn_count;
         if (ca->sendq
 // attempt to fix hot i/o bug
-            && ca->unack_attn_count < 10
+            && unack_attn_count < 10
         )
         {
-            ca->unack_attn_count++;
+            ca->unack_attn_count = ++unack_attn_count;
             rc = device_attention(ca->dev, CSW_ATTN);
             if(ca->dev->ccwtrace)
                 WRMSG(HHC01057, "D",
                     SSID_TO_LCSS(ca->dev->ssid), ca->dev->devnum, rc);
         }
+        release_lock(&ca->lock);
+
+        if(ca->ackspeed == 0) delay = 50000 + (unack_attn_count * 100000);     /* Max's reliable algorithm      */
+        else delay = (unack_attn_count * unack_attn_count + 1) * ca->ackspeed; /* much faster but TCAM hates it */
+        USLEEP(min((int)(ONE_MILLION-1),delay));                               /* go to sleep, max. 1 second    */
     }
-    // end while(!sysblk.shutdown)
+    // end while(TRUE)
+    ca->haltpending=0;
+    ca->have_cthread=0;                 /* DETACHED thread no longer exists! */
+    memset(&ca->cthread, 0, sizeof(TID));
+    signal_condition(&ca->ipc_halt);    /* Tell the halt initiator too */
 
     LOG_THREAD_END( threadname );
     release_lock(&ca->lock);
@@ -1450,6 +1466,7 @@ static int commadpt_init_handler (DEVBLK *dev, int argc, char *argv[])
     if(rc)
     {
         WRMSG(HHC00102, "E" ,strerror(rc));
+        memset(&dev->commadpt->tthread, 0, sizeof(TID));
         release_lock(&dev->commadpt->lock);
         return -1;
     }
@@ -1465,6 +1482,9 @@ static int commadpt_init_handler (DEVBLK *dev, int argc, char *argv[])
     if(rc)
     {
         WRMSG(HHC00102, "E", strerror(rc));
+
+        /* #TODO: Shutdown telnet_thread? */
+        memset(&dev->commadpt->cthread, 0, sizeof(TID));
         release_lock(&dev->commadpt->lock);
         return -1;
     }
@@ -1504,17 +1524,40 @@ static int commadpt_close_device( DEVBLK* dev )
         WRMSG( HHC01060, "D", LCSS_DEVNUM );
     }
 
-    obtain_lock( &dev->commadpt->lock );
-    {
-        /* Terminate current I/O thread if necessary */
-        if (dev->busy)
-            commadpt_halt_or_clear( dev );
+    /* Terminate current I/O thread if necessary */
+    if (dev->busy)
+        commadpt_halt_or_clear( dev );
 
-        free_bufpool( dev->commadpt );
+    /* Obtain the CA lock */
+    obtain_lock( &dev->commadpt->lock );
+
+    /* Terminate worker thread if it is still up */
+    if (dev->commadpt->have_cthread)
+    {
+        /*
+         * commadpt_thread presently has a lock-order inversion:
+         * obtain_lock(&ca->lock) is called before device_attention() which
+         * attempts to OBTAIN_DEVLOCK. This is the reverse of the ordering
+         * assumed here (i.e., when the device close handler is invoked).
+         *
+         * Temporarily release the DEVLOCK to allow commadpt_thread to perform
+         * one final iteration and exit.
+         */
+        RELEASE_DEVLOCK( dev );
+        {
+            dev->commadpt->haltpending = 1;
+            wait_condition( &dev->commadpt->ipc_halt, &dev->commadpt->lock );
+        }
+        OBTAIN_DEVLOCK( dev );
+
+        ASSERT( !dev->commadpt->have_cthread );
     }
+
+    /* Release the CA lock */
     release_lock( &dev->commadpt->lock );
 
     /* Free all work storage */
+    free_bufpool( dev->commadpt );
     commadpt_clean_device( dev );
 
     /* Indicate to hercules the device is no longer opened */

--- a/commadpt.c
+++ b/commadpt.c
@@ -1323,9 +1323,7 @@ static void *commadpt_thread(void *vca)
         if(!socket_is_socket(ca->lfd))
         {
             WRMSG(HHC01002, "E",SSID_TO_LCSS(ca->dev->ssid),devnum,strerror(HSO_errno));
-            ca->have_cthread=0;
-            release_lock(&ca->lock);
-            return NULL;
+            goto commadpt_thread_exit;
         }
         /* Turn blocking I/O off */
         /* set socket to NON-blocking mode */
@@ -1985,7 +1983,17 @@ static void *commadpt_thread(void *vca)
             }
         }
     }
+
+    /* If we were listening and a socket was created */
+    if (ca->dolisten && socket_is_socket(ca->lfd))
+        close_socket(ca->lfd);
+
+commadpt_thread_exit:
+    ca->lfd=-1;
     ca->curpending=COMMADPT_PEND_CLOSED;
+    ca->have_cthread=0; /* DETACHED thread no longer exists! */
+    memset(&ca->cthread, 0, sizeof(TID));
+
     /* Check if we already signaled the init process  */
     if(!init_signaled)
     {
@@ -2032,6 +2040,9 @@ static void commadpt_halt_or_clear( DEVBLK* dev )
     if (dev->busy)
     {
         obtain_lock( &dev->commadpt->lock );
+
+        /* Signal halt to worker thread if it is still up */
+        if (dev->commadpt->have_cthread)
         {
             commadpt_wakeup( dev->commadpt, 1 );
 
@@ -2658,6 +2669,7 @@ static int commadpt_init_handler (DEVBLK *dev, int argc, char *argv[])
     if(rc)
     {
         WRMSG(HHC00102, "E", strerror(rc));
+        memset(&dev->commadpt->cthread, 0, sizeof(TID));
         release_lock(&dev->commadpt->lock);
         return -1;
     }
@@ -2729,8 +2741,7 @@ static int commadpt_close_device( DEVBLK* dev )
         commadpt_wakeup( dev->commadpt, 0 );
         commadpt_wait( dev );
 
-        dev->commadpt->cthread      = (TID) -1;
-        dev->commadpt->have_cthread = 0;
+        ASSERT( !dev->commadpt->have_cthread );
     }
 
 


### PR DESCRIPTION
Address a lock-order-inversion and use-after-free when exiting and/or cleaning up the 3705 controller. While fixing these issues, also apply some related cleanup:

1. Ensure lfd sockets are closed when worker threads exit.
2. Make termination handling consistent across comm3705, commadpt, and tcpnje (which already share similar implementations).
3. Ensure `commadpt_halt_or_clear` waits only while the worker thread is still running (matching comm3705 behavior and avoiding CPU hangs).

Note: I initially reported this in #827, and the resulting changes are somewhat ugly...

## lock-order-inversion

Reported by TSAN, but the general outline is as follows:

```
  commadpt_thread:
    -> obtain_lock(&ca->lock); // ca=(COMMADPT *)dev->commadpt;
    -> device_attention
      -> OBTAIN_DEVLOCK( dev );

  quit_thread:
    release_config
      -> detach_device
        -> detach_devblk
          -> OBTAIN_DEVLOCK( dev );
          -> commadpt_close_device
            -> obtain_lock( &dev->commadpt->lock );
```

## use-after-free

Example MemorySanitizer output, note line numbers **may** reference an older state of the 'develop' branch:

```
==382058==WARNING: MemorySanitizer: use-of-uninitialized-value
    .0 0x7f80762902d4 in hthread_obtain_lock $(DEV)/hyperion/build/../hthreads.c:510:10
    .1 0x7f8073718a58 in commadpt_thread $(DEV)/hyperion/build/../comm3705.c:1228:9
    .2 0x7f80762946a3 in hthread_func $(DEV)/hyperion/build/../hthreads.c:1059:10
    .3 0x7f80741868f8 in start_thread (/lib64/libc.so.6+0x738f8)
    .4 0x7f807420ac0b in __GI___clone3 (/lib64/libc.so.6+0xf7c0b)

  Uninitialized value was created by a heap deallocation
    .0 0x000000435cb4 in free ($(DEV)/hyperion/build/.libs/hercules+0x435cb4)
    .1 0x7f8073711aeb in commadpt_clean_device $(DEV)/hyperion/build/../comm3705.c:897:9
    .2 0x7f80737112ee in commadpt_close_device $(DEV)/hyperion/build/../comm3705.c:1518:5
    .3 0x7f8074793882 in detach_devblk $(DEV)/hyperion/build/../config.c:799:9
    .4 0x7f807478ce44 in detach_device $(DEV)/hyperion/build/../config.c:1461:10
    .5 0x7f807478b9ad in release_config $(DEV)/hyperion/build/../config.c:902:17
    .6 0x7f807626f054 in hdl_atexit $(DEV)/hyperion/build/../hdl.c:693:13
    .7 0x7f807558c41a in do_shutdown_now $(DEV)/hyperion/build/../hscmisc.c:1612:5
    .8 0x7f807548958f in quit_thread $(DEV)/hyperion/build/../hsccmd.c:786:5
    .9 0x7f80762946a3 in hthread_func $(DEV)/hyperion/build/../hthreads.c:1059:10
    .10 0x7f80741868f8 in start_thread (/lib64/libc.so.6+0x738f8)
```

Similar warnings from the same heap deallocation:

```
==382058==WARNING: MemorySanitizer: use-of-uninitialized-value
    .0 0x7f80762902e5 in hthread_obtain_lock $(DEV)/hyperion/build/../hthreads.c:529:9
    .1 0x7f8073718a58 in commadpt_thread $(DEV)/hyperion/build/../comm3705.c:1228:9
    .2 0x7f80762946a3 in hthread_func $(DEV)/hyperion/build/../hthreads.c:1059:10
    .3 0x7f80741868f8 in start_thread (/lib64/libc.so.6+0x738f8) (BuildId: adb97a93b3ce215bd1c316a17ac7abffa500675e)
    .4 0x7f807420ac0b in __GI___clone3 (/lib64/libc.so.6+0xf7c0b) (BuildId: adb97a93b3ce215bd1c316a17ac7abffa500675e)

==382058==WARNING: MemorySanitizer: use-of-uninitialized-value
    .0 0x7f807371ad6f in make_sna_requests3 %(DEV)/hyperion/build/../comm3705.c:1704:9
    .1 0x7f8073718a68 in commadpt_thread %(DEV)/hyperion/build/../comm3705.c:1230:9
    .2 0x7f80762946a3 in hthread_func %(DEV)/hyperion/build/../hthreads.c:1059:10
    .3 0x7f80741868f8 in start_thread (/lib64/libc.so.6+0x738f8) (BuildId: adb97a93b3ce215bd1c316a17ac7abffa500675e)
    .4 0x7f807420ac0b in __GI___clone3 (/lib64/libc.so.6+0xf7c0b) (BuildId: adb97a93b3ce215bd1c316a17ac7abffa500675e)
```