### PR TITLE
mark unjoined threads as detached

### DIFF
--- a/cckddasd.c
+++ b/cckddasd.c
@@ -1492,7 +1492,7 @@ int             rc;
             /* Release lock across thread create to prevent interlock  */
             release_lock(&cckdblk.ralock);
             {
-                rc = create_thread( &tid, JOINABLE, cckd_ra, NULL, CCKD_RA_THREAD_NAME );
+                rc = create_thread( &tid, DETACHED, cckd_ra, NULL, CCKD_RA_THREAD_NAME );
             }
             obtain_lock(&cckdblk.ralock);
 
@@ -1626,7 +1626,7 @@ int             ras;
                 /* Release lock across thread create to prevent interlock  */
                 release_lock(&cckdblk.ralock);
                 {
-                    rc = create_thread( &tid, JOINABLE, cckd_ra, NULL, CCKD_RA_THREAD_NAME );
+                    rc = create_thread( &tid, DETACHED, cckd_ra, NULL, CCKD_RA_THREAD_NAME );
                 }
                 obtain_lock(&cckdblk.ralock);
 
@@ -1699,7 +1699,7 @@ void cckd_dhstart( bool by_cmdline )
 
             ++cckdblk.dhs;
 
-            rc = create_thread( &tid, JOINABLE, cckd_dh, NULL, CCKD_DH_THREAD_NAME );
+            rc = create_thread( &tid, DETACHED, cckd_dh, NULL, CCKD_DH_THREAD_NAME );
 
             if (rc)
             {
@@ -1942,7 +1942,7 @@ TID             tid;                    /* Writer thread id          */
             /* Release lock across thread create to prevent interlock  */
             release_lock(&cckdblk.wrlock);
             {
-                rc = create_thread( &tid, JOINABLE, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
+                rc = create_thread( &tid, DETACHED, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
             }
             obtain_lock(&cckdblk.wrlock);
 
@@ -2145,7 +2145,7 @@ int             wrs;
                 /* Release lock across thread create to prevent interlock  */
                 release_lock( &cckdblk.wrlock );
                 {
-                    rc = create_thread( &tid, JOINABLE, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
+                    rc = create_thread( &tid, DETACHED, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
                 }
                 obtain_lock( &cckdblk.wrlock );
 
@@ -5389,7 +5389,7 @@ void cckd_gcstart( bool by_cmdline )
 
                 ++cckdblk.gcs;
 
-                rc = create_thread( &tid, JOINABLE, cckd_gcol, NULL, CCKD_GC_THREAD_NAME );
+                rc = create_thread( &tid, DETACHED, cckd_gcol, NULL, CCKD_GC_THREAD_NAME );
 
                 if (rc)
                 {

--- a/cckddasd64.c
+++ b/cckddasd64.c
@@ -1174,7 +1174,7 @@ TID             tid;                    /* Writer thread id          */
             /* Release lock across thread create to prevent interlock  */
             release_lock(&cckdblk.wrlock);
             {
-                rc = create_thread( &tid, JOINABLE, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
+                rc = create_thread( &tid, DETACHED, cckd_writer, NULL, CCKD_WR_THREAD_NAME );
             }
             obtain_lock(&cckdblk.wrlock);
 

--- a/ctc_ptp.c
+++ b/ctc_ptp.c
@@ -3844,7 +3844,7 @@ int  raise_unsol_int( DEVBLK* pDEVBLK, BYTE bStatus, int iDelay )
     MSGBUF( thread_name, "%s %4.4X UnsolIntThread",
                          pPTPBLK->pDEVBLKRead->typname,
                          pPTPBLK->pDEVBLKRead->devnum);
-    rc = create_thread( &tid, JOINABLE, ptp_unsol_int_thread, pPTPINT, thread_name );
+    rc = create_thread( &tid, DETACHED, ptp_unsol_int_thread, pPTPINT, thread_name );
     if (rc)
     {
         // Report the bad news.

--- a/ctcadpt.c
+++ b/ctcadpt.c
@@ -1178,7 +1178,7 @@ static int  CTCT_Init( DEVBLK *dev, int argc, char *argv[] )
         arg->dev = dev;
         MSGBUF(str, "CTCT %4.4X ListenThread",dev->devnum);
         str[sizeof(str)-1]=0;
-        rc = create_thread( &tid, JOINABLE, CTCT_ListenThread, arg, str );
+        rc = create_thread( &tid, DETACHED, CTCT_ListenThread, arg, str );
         if(rc)
            WRMSG(HHC00102, "E", strerror(rc));
     }

--- a/hao.c
+++ b/hao.c
@@ -90,7 +90,7 @@ static int hao_initialize()
     memset( ao_msgbuf, 0, sizeof( ao_msgbuf ));
 
     /* Start message monitoring thread */
-    rc = create_thread( &haotid, JOINABLE, hao_thread, NULL, HAO_THREAD_NAME );
+    rc = create_thread( &haotid, DETACHED, hao_thread, NULL, HAO_THREAD_NAME );
     if (rc)
     {
         rc = FALSE;
@@ -657,6 +657,9 @@ static void* hao_thread(void* dummy)
             memmove( ao_msgbuf, msgbuf, bufamt -= (msgbuf - ao_msgbuf) );
         }
     }
+
+    /* Since the thread is 'detached' clear the static field on exit */
+    memset(&haotid, 0, sizeof(TID));
 
     // "Thread id "TIDPAT", prio %d, name '%s' ended"
     LOG_THREAD_END( HAO_THREAD_NAME  );

--- a/logger.c
+++ b/logger.c
@@ -623,7 +623,7 @@ DLL_EXPORT void logger_init( void )
 
     setvbuf( logger_syslog[ LOG_WRITE ], NULL, _IONBF, 0 );
 
-    rc = create_thread( &sysblk.loggertid, JOINABLE,
+    rc = create_thread( &sysblk.loggertid, DETACHED,
                         logger_thread, NULL, LOGGER_THREAD_NAME );
     if (rc)
     {


### PR DESCRIPTION
Mark threads created by `create_thread` as detached when:

1. The supplied thread ID is a local variable and never used outside the create_thread invocation.
2. The supplied thread ID is stored in a global variable but no logic exists to join the thread.

The first case is generally more important as terminated threads otherwise become zombies, i.e., no longer executing but their resources remained allocated. 

In the second case, for example, the logger thread exits only when the write end of its pipe is closed, causing the corresponding read operation to fail (this _normally_ occurs during program shutdown). Since the thread is never joined under any circumstance, create it as detached rather than joinable.