### PR TITLE
service.c: fix msglen underflow in gh534_fix

### DIFF
--- a/service.c
+++ b/service.c
@@ -268,7 +268,7 @@ static void gh534_fix( int msglen, BYTE* /*EBCDIC*/ e_msg )
             */
             if (*(p+1) == 'K')
             {
-                msglen -= (p + 2) - a_msg;
+                msglen -= 2;
                 memmove( a_msg, p + 2, msglen + 1 );
                 p = a_msg;
                 continue;


### PR DESCRIPTION
Pinging @JamesWekel again (... since you have been updating this codepath recently).

Since `msglen` is the length of the string starting at p, subtracting `(p + 2) - a_msg` (an absolute offset) from it causes msglen to become negative, resulting in an invalid size_t being passed to memmove.

String pulled from Ubuntu 20.04 for s390x (note: the string seems a bit weird).
```c
    static const BYTE e_msg[] = {
        0x4a, 0xf7, 0x94, 0x93, 0x89, 0x95, 0x85, 0xa2, 0x40, 0xf1, 0x60, 0xf2,
        0xf3, 0x4a, 0xf2, 0xf7, 0x94, 0x4a, 0xd2,
    };
```

(Edit: fixed my stupidity in describing the issue)