### PR TITLE
x75.c: resume a restarted copy where the host buffer left off

### DIFF
--- a/tcpip.c
+++ b/tcpip.c
@@ -1067,6 +1067,35 @@ static void EZASOKET (u_int  func, int  aux1, int  aux2, talk_ptr t) {
 
 /**********************************************************************************/
 /*
+  Where in the host buffer a copy has to resume.
+
+  X'75' is restartable by design: a page translation exception on the guest
+  buffer is nullifying, so the instruction runs again from the top with R0
+  saying the native call was already made and R1 saying how much is left. The
+  guest side of the copy resumes correctly because the base register was
+  advanced before the exception. The host side has no such register -- R2 is a
+  slot index into map32 [] and never moves -- so the resume point is derived
+  here instead, from what is still outstanding in R1 against the length this
+  conversation was given.
+*/
+
+u_int  lar_offset (u_int  * regs) {
+    talk_ptr t;
+    u_int    len;
+    u_int    left;
+
+    t = (talk_ptr)map32[get_reg (regs, 14)];
+
+    len  = (get_reg (regs, 3) == 0) ? t->len_in : t->len_out;
+    left = get_reg (regs, 1);
+
+    if (left >= len) return (0); /* First entry: nothing copied yet */
+
+    return (len - left);
+}
+
+/**********************************************************************************/
+/*
   R0  = 0 (Initially, but turns to > 0 after the native call.
   R1  = Byte Counter
   R2  = Source/Destination of PC buffer.  32bits.

--- a/x75.c
+++ b/x75.c
@@ -99,7 +99,12 @@ DEF_INST( tcpip )
         regs->GR_L(0) = 1;    /* Do not call native routine again */
     }
 
-    if (regs->GR_L(1) != 0) s = (unsigned char *)(map32[regs->GR_L(2)]);
+    /* R2 is a slot index and never moves, so the host side of the copy has  */
+    /* no register of its own to resume from after a nullifying exception.   */
+    /* lar_offset () derives that resume point from R1.                      */
+
+    if (regs->GR_L(1) != 0)
+        s = (unsigned char *)(map32[regs->GR_L(2)]) + lar_offset (&(regs->gr [0]));
 
     while (regs->GR_L(1) != 0) { /* Finished > */
 

--- a/x75.h
+++ b/x75.h
@@ -4,5 +4,7 @@
 /*-------------------------------------------------------------------*/
 
 extern int lar_tcpip (DW * regs); /* function in tcpip.c             */
+extern unsigned int lar_offset (DW * regs); /* ditto: resume point of */
+                                  /* a copy into/out of the host buffer */
 extern U_LONG_PTR map32[Ccom];    /* map 64-bit host addresses       */
                                   /* to 32-bit guest registers       */


### PR DESCRIPTION
Fixes #884.

X'75' copies between the guest buffer and the host buffer in 256-byte segments,
and the instruction is restartable by design. A page translation exception on
the guest buffer is nullifying, so the instruction runs again from the top: R0
records that the native call has already been made, R1 holds the bytes still
outstanding, and the base register was advanced before the exception. The guest
side of the copy therefore resumes exactly where it stopped.

The host side does not. `s` is a local, recomputed from `map32[R2]` on every
entry, and R2 is a slot index that never advances, so the remaining bytes are
copied from the **start** of the host buffer to the already advanced guest
address.

256 bytes or less is immune by construction: `vstorec()` resolves both page
addresses through `MADDRL` before either `memcpy`, so a segment either faults
having copied nothing -- where resuming from the start is correct -- or it
completes. The defect needs at least one completed segment, which is why it only
shows above 256 bytes.

### The change

Give the host side a resume point, derived rather than tracked. The bytes
already copied are the length this conversation was given minus what R1 still
says is outstanding, and both lengths are already in the `talk` structure that
`map32[R14]` resolves. `lar_offset()` returns that difference; `x75.c` adds it
to the buffer base.

Both directions hold on inspection of `lar_tcpip()`: for `R3 = 0` the initial
call sets `t->len_in` from R1, and for `R3 = 1` it sets R1 from `t->len_out`. R1
therefore starts each copy exactly equal to the length it is compared against,
so the first entry yields 0 and `left > len` cannot arise. `t->len_out` is
explicitly zeroed when the `talk` is created, so the `R3 = 1` arm cannot read an
uninitialised length out of a structure that is `malloc`ed without zeroing.

R0 stays the flag it is today rather than becoming a counter. Widening it was
the smaller diff and the two guest stubs we can read allow it, but a third
issuer exists that cannot be inspected from here -- Shelby Beach's EZASMI
backend `EZASOH03` -- and leaving R0 alone means no issuer, read or unread, can
be broken by this.

No function code, no return code and no guest-visible register usage changes.

### Measured

The fault is forced rather than waited for. A guest probe places a page boundary
at a chosen multiple of 256 inside a 1024-byte receive buffer, releases the page
beyond it with `PGRLSE` immediately before the receive, and receives over a
loopback pair it owns both ends of. The receive goes through the low-level
`__75()` entry rather than `recv()`, so one measurement is one pair of X'75'
instructions with no retry loop.

A diagnostic build logs every entry with `GR_L(0) != 0` -- exactly a restart,
since every issuer zeroes R0 with `SLR 0,0` beforehand -- together with the
bytes the nullified copy had already moved. Two builds differing by this one
line, run on MVS 3.8j (MVS/CE):

| Boundary | before: bytes copied / first bad byte | after: bytes copied / first bad byte |
|---|---|---|
| 0 (control) | 0 / none | 0 / none |
| 256 | 256 / **256** | 256 / none |
| 512 | 512 / **512** | 512 / none |
| 768 | 768 / **768** | 768 / none |

Before: `JOB03045`, RC=8. After: `JOB03046`, RC=0.

Two things make this more than a clean run. In every failing case the emulator's
count of bytes already copied equals the guest's first bad byte, and the tail is
a clean replay of the host buffer from its start -- the mechanism named, not
just a mismatch observed. And the **three restarts after a completed segment
still occur after the change, with the same counts**: the fault rate did not
move, only the resume path. Restarts disappearing would have proved nothing,
which is why the instrumentation stays in place across both halves.

The control case at boundary 0 faults having copied nothing and is clean before
and after, as the mechanism predicts.

### Soak

The fix has since run as the installed build on a live MVS 3.8j system for 24
hours, with the probe submitted hourly. 27 runs, 27 × RC=0, each one forcing the
fault. Listening sockets, threads and open descriptors are unchanged over the
whole period; resident size grew ~7 MB on a 60 MB process and levelled off,
tracking the operator's own HTTP workload rather than the probe.

### Reproducing it

Both halves are public:

- probe: `mvslovers/libc370`, `test/mvs/tst75rst.c` with `jcl/tst75rst.jcl`
- instrumented emulator: `mvslovers/hyperion`, branch `diag/x75-restart-trace` --
  the unfixed half is `HEAD~1`, the fixed half `HEAD`, and they differ by the
  one line in this PR

### Guest compatibility

A guest cannot detect a patched emulator: there is no return value, status bit
or function code that distinguishes one. Existing guest-side length caps
therefore stay where they are regardless of this fix, and the correct guest-side
cap is 256 rather than 4096.

### On making it optional

#863 was made a compile-time option on review so it could be backed out if side
effects appeared, and the same question is reasonable here. This one differs in
what there would be to back out: the change alters behaviour only on the path
where a copy was nullified mid-transfer, and the current behaviour on that path
is silent data corruption. A switch would make that reachable again rather than
provide a safe fallback. Happy to add one under `featall.h` if you would still
prefer it.

Builds clean against current `develop` with gcc (Debian 13); no new warnings in
`x75.c` or `tcpip.c`.
